### PR TITLE
Silence almost all the g++ compiler warnings.  Use struct Pkt in

### DIFF
--- a/simulator/receiver.cpp
+++ b/simulator/receiver.cpp
@@ -163,7 +163,7 @@ void *Receiver::loopRecv(int tid)
         printf("Error setting buffer size to %d\n", sock_buf_size);
     }
     else {     
-        int res = getsockopt(socket_local, SOL_SOCKET, SO_RCVBUF, &sock_buf_size, &optlen);
+        getsockopt(socket_local, SOL_SOCKET, SO_RCVBUF, &sock_buf_size, &optlen);
         printf("Set socket %d buffer size to %d\n", tid, sock_buf_size);
     }
 
@@ -186,24 +186,21 @@ void *Receiver::loopRecv(int tid)
     int buffer_frame_num = buffer_frame_num_;
     double *frame_start = frame_start_[tid];
 
+#if 0
     // walk through all the pages
     double temp;
     for (int i = 0; i < 20; i++) {
         temp = frame_start[i * 512];
     }
-
+#endif
 
     char* cur_buffer_ptr = buffer_ptr;
     int* cur_buffer_status_ptr = buffer_status_ptr;
     // loop recv
     socklen_t addrlen = sizeof(servaddr_local);
     int offset = 0;
-    int packet_num = 0;
-    int ret = 0;
-    int max_subframe_id = downlink_mode ? UE_NUM : subframe_num_perframe;
     int prev_frame_id = -1;
-    int packet_num_per_frame = 0;
-    double start_time= get_time();
+    // double start_time= get_time();
 
 
     // printf("Rx thread %d: on core %d\n", tid, sched_getcpu());
@@ -224,11 +221,11 @@ void *Receiver::loopRecv(int tid)
 
     #if MEASURE_TIME
         // read information from received packet
-        int ant_id, frame_id, subframe_id, cell_id;
-        frame_id = *((int *)cur_buffer_ptr);
-        subframe_id = *((int *)cur_buffer_ptr + 1);
-        // cell_id = *((int *)cur_buffer_ptr + 2);
-        ant_id = *((int *)cur_buffer_ptr + 3);
+        struct Packet *pkt = (struct Packet *)cur_buffer_ptr;
+        int frame_id = pkt->frame_id;
+        // int subframe_id = pkt->symbol_id;
+        // int cell_id = pkt->cell_id;
+        // int ant_id = pkt->ant_id;
         // printf("RX thread %d received frame %d subframe %d, ant %d, msg queue length %d\n", tid, frame_id, subframe_id, ant_id, message_queue_->size_approx());
         if (frame_id > prev_frame_id) {
             *(frame_start + frame_id) = get_time();

--- a/src/common/Symbols.hpp
+++ b/src/common/Symbols.hpp
@@ -129,22 +129,6 @@ typedef enum {
 	Master_TX,
 } thread_type;
 
-static const char *THREAD_TYPE_STRING[] = {
-	"Master",
-	"Worker",
-	"Worker (FFT)",
-	"Worker (ZF)",
-	"Worker (Demul)",
-	"RX",
-	"TX",
-	"TXRX",
-	"Master (RX)",
-	"Master (TX)"
-};
-
-
-
-
 struct LDPCconfig {
     uint16_t Bg;
     bool earlyTermination;

--- a/src/common/net.cpp
+++ b/src/common/net.cpp
@@ -14,7 +14,7 @@ void set_socket_buf_size(int socket_local, int sock_buf_size)
         printf("Error setting buffer size to %d\n", sock_buf_size);
     }
     else {     
-        int res = getsockopt(socket_local, SOL_SOCKET, SO_RCVBUF, &sock_buf_size, &optlen);
+        getsockopt(socket_local, SOL_SOCKET, SO_RCVBUF, &sock_buf_size, &optlen);
         printf("Set socket buffer size to %d\n", sock_buf_size);
     }
 }

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -25,6 +25,18 @@ int pin_to_core(int core_id) {
 
 void pin_to_core_with_offset(thread_type thread, int core_offset, int thread_id) {
 #ifdef ENABLE_CPU_ATTACH
+    const char *THREAD_TYPE_STRING[] = {
+	"Master",
+	"Worker",
+	"Worker (FFT)",
+	"Worker (ZF)",
+	"Worker (Demul)",
+	"RX",
+	"TX",
+	"TXRX",
+	"Master (RX)",
+	"Master (TX)"
+    };
     int actual_core_id = core_offset + thread_id;
     int num_cores = sysconf(_SC_NPROCESSORS_ONLN);
     /* reserve core 0 for kernel threads */

--- a/src/millipede/dofft.cpp
+++ b/src/millipede/dofft.cpp
@@ -95,12 +95,11 @@ void DoFFT::FFT(int offset)
     // printf("In doFFT: socket_thread: %d offset %d\n", socket_thread_id, offset);
     // read info of one frame
     char *cur_buffer_ptr = socket_buffer_[socket_thread_id] + (long long) offset * packet_length;
-
-    int ant_id, frame_id, subframe_id; //, cell_id;
-    frame_id = *((int *)cur_buffer_ptr);
-    subframe_id = *((int *)cur_buffer_ptr + 1);
-    // cell_id = *((int *)cur_buffer_ptr + 2);
-    ant_id = *((int *)cur_buffer_ptr + 3);
+    struct Packet *pkt = (struct Packet *)cur_buffer_ptr;
+    int frame_id = pkt->frame_id % 10000;
+    int subframe_id = pkt->symbol_id;
+    // int cell_id = pkt->cell_id;
+    int ant_id = pkt->ant_id;
     // printf("thread %d process frame_id %d, subframe_id %d, cell_id %d, ant_id %d\n", tid, frame_id, subframe_id, cell_id, ant_id);
     // remove CP, do FFT
     // int delay_offset = 0;

--- a/src/millipede/doprecode.cpp
+++ b/src/millipede/doprecode.cpp
@@ -96,7 +96,7 @@ void DoPrecode::Precode(int offset)
             }
 
             complex_float *data_ptr;
-            if (current_data_subframe_id == config_->dl_data_symbol_start - 1 + DL_PILOT_SYMS) {
+            if ((unsigned)current_data_subframe_id == config_->dl_data_symbol_start - 1 + DL_PILOT_SYMS) {
                 data_ptr = modulated_buffer_temp;
                 for (int user_id = 0; user_id < UE_NUM; user_id ++)
                     *(data_ptr + user_id) = {config_->pilots_[cur_sc_id], 0};

--- a/src/millipede/stats.cpp
+++ b/src/millipede/stats.cpp
@@ -563,8 +563,10 @@ void Stats::print_summary(int last_frame_id)
     int FFT_total_count = compute_total_count(fft_stats_worker, task_thread_num);
     int ZF_total_count = compute_total_count(zf_stats_worker, task_thread_num);
     int Demul_total_count = compute_total_count(demul_stats_worker, task_thread_num);
+#if USE_LDPC
     int Decode_total_count = compute_total_count(decode_stats_worker, task_thread_num);
     int Encode_total_count = compute_total_count(encode_stats_worker, task_thread_num);
+#endif
     int IFFT_total_count = compute_total_count(ifft_stats_worker, task_thread_num);
     int Precode_total_count = compute_total_count(precode_stats_worker, task_thread_num);
     if (downlink_mode) {
@@ -572,12 +574,11 @@ void Stats::print_summary(int last_frame_id)
         double precode_frames = (double) Precode_total_count / OFDM_DATA_NUM / dl_data_subframe_num_perframe;
         double ifft_frames = (double) IFFT_total_count / BS_ANT_NUM / dl_data_subframe_num_perframe;
         double zf_frames = (double) ZF_total_count / OFDM_DATA_NUM;
-        double encode_frames = (double) Encode_total_count / LDPC_config.nblocksInSymbol / UE_NUM / dl_data_subframe_num_perframe;
         printf("Downlink: total performed ");
         printf("CSI %d (%.2f frames), ", CSI_total_count, csi_frames);
         printf("ZF: %d (%.2f frames), ", ZF_total_count, zf_frames);
         #if USE_LDPC
-        printf("Encode: %d (%.2f frames), ", Encode_total_count, encode_frames);
+        double encode_frames = (double) Encode_total_count / LDPC_config.nblocksInSymbol / UE_NUM / dl_data_subframe_num_perfram        printf("Encode: %d (%.2f frames), ", Encode_total_count, encode_frames);
         #endif
         printf("Precode: %d (%.2f frames), ", Precode_total_count, precode_frames);
         printf("IFFT: %d (%.2f frames)", IFFT_total_count, ifft_frames);
@@ -587,11 +588,11 @@ void Stats::print_summary(int last_frame_id)
             double percent_ZF = compute_count_percentage(zf_stats_worker, ZF_total_count, i);
             double percent_Precode = compute_count_percentage(precode_stats_worker, Precode_total_count, i);
             double percent_IFFT = compute_count_percentage(ifft_stats_worker, IFFT_total_count, i);
-            double percent_Encode = compute_count_percentage(encode_stats_worker, Encode_total_count, i);
             printf("thread %d performed ", i);
             printf("CSI: %d (%.2f%%), ", csi_stats_worker.task_count[i * 16], percent_CSI);
             printf("ZF: %d (%.2f%%), ", zf_stats_worker.task_count[i * 16], percent_ZF);
             #if USE_LDPC
+            double percent_Encode = compute_count_percentage(encode_stats_worker, Encode_total_count, i);
             printf("Encode: %d (%.2f%%), ", encode_stats_worker.task_count[i * 16], percent_Encode);
             #endif
             printf("Precode: %d (%.2f%%), ", precode_stats_worker.task_count[i * 16], percent_Precode);
@@ -604,14 +605,13 @@ void Stats::print_summary(int last_frame_id)
         double fft_frames = (double) FFT_total_count / BS_ANT_NUM / ul_data_subframe_num_perframe;
         double demul_frames = (double) Demul_total_count / OFDM_DATA_NUM / ul_data_subframe_num_perframe;
         double zf_frames = (double) ZF_total_count / OFDM_DATA_NUM;
-        double decode_frames = (double) Decode_total_count / LDPC_config.nblocksInSymbol / UE_NUM / ul_data_subframe_num_perframe;
         printf("Uplink: total performed ");
         printf("CSI %d (%.2f frames), ", CSI_total_count, csi_frames);  
         printf("ZF: %d (%.2f frames), ", ZF_total_count, zf_frames);
         printf("FFT: %d (%.2f frames), ", FFT_total_count, fft_frames);
         printf("Demul: %d (%.2f frames) ", Demul_total_count, demul_frames);
         #if USE_LDPC
-        printf("Decode: %d (%.2f frames)", Decode_total_count, decode_frames);
+        double decode_frames = (double) Decode_total_count / LDPC_config.nblocksInSymbol / UE_NUM / ul_data_subframe_num_perfram        printf("Decode: %d (%.2f frames)", Decode_total_count, decode_frames);
         #endif
         printf("\n");
         for (int i = 0; i < task_thread_num; i++) {
@@ -619,13 +619,13 @@ void Stats::print_summary(int last_frame_id)
             double percent_FFT = compute_count_percentage(fft_stats_worker, FFT_total_count, i);;
             double percent_ZF = compute_count_percentage(zf_stats_worker, ZF_total_count, i);
             double percent_Demul = compute_count_percentage(demul_stats_worker, Demul_total_count, i);
-            double percent_Decode = compute_count_percentage(decode_stats_worker, Decode_total_count, i);
             printf("thread %d performed ", i);
             printf("CSI: %d (%.2f%%), ", csi_stats_worker.task_count[i * 16], percent_CSI);
             printf("ZF: %d (%.2f%%), ", zf_stats_worker.task_count[i * 16], percent_ZF);
             printf("FFT: %d (%.2f%%), ", fft_stats_worker.task_count[i * 16], percent_FFT);
             printf("Demul: %d (%.2f%%) ", demul_stats_worker.task_count[i * 16], percent_Demul);
             #if USE_LDPC
+            double percent_Decode = compute_count_percentage(decode_stats_worker, Decode_total_count, i);
             printf("Decode: %d (%.2f%%) ", decode_stats_worker.task_count[i * 16], percent_Decode);
             #endif
             printf("\n"); 

--- a/src/millipede/txrx/txrx.cpp
+++ b/src/millipede/txrx/txrx.cpp
@@ -169,11 +169,12 @@ void *PacketTXRX::loopRecv(int tid)
     double *frame_start = frame_start_[tid];
 
     // walk through all the pages
+#if 0
     double temp;
     for (int i = 0; i < 20; i++) {
         temp = frame_start[i * 512];
     }
-
+#endif
 
     char* cur_buffer_ptr = buffer_ptr;
     int* cur_buffer_status_ptr = buffer_status_ptr;
@@ -212,11 +213,11 @@ void *PacketTXRX::loopRecv(int tid)
 
     #if MEASURE_TIME
         // read information from received packet
-        int frame_id; //, subframe_id, ant_id, cell_id;
-        frame_id = *((int *)cur_buffer_ptr);
-        // subframe_id = *((int *)cur_buffer_ptr + 1);
-        // cell_id = *((int *)cur_buffer_ptr + 2);
-        // ant_id = *((int *)cur_buffer_ptr + 3);
+	struct Packet *pkt = (struct Packet *)cur_buffer_ptr;
+        int frame_id = pkt->frame_id;
+        // int subframe_id = pkt->symbol_id;
+        // int cell_id = pkt->cell_id;
+        // int ant_id = pkt->ant_id;
         // printf("RX thread %d received frame %d subframe %d, ant %d\n", tid, frame_id, subframe_id, ant_id);
         if (frame_id > prev_frame_id) {
             *(frame_start + frame_id) = get_time();
@@ -274,8 +275,9 @@ void *PacketTXRX::loopSend(int tid)
     int offset;
     char *cur_buffer_ptr;
     // int *cur_ptr_buffer_status;
-    int ant_id, frame_id, symbol_id, total_data_subframe_id, current_data_subframe_id;
-    int cell_id = 0;
+    int ant_id, frame_id, symbol_id, current_data_subframe_id;
+    // int total_data_sumframe_id;
+    // int cell_id = 0;
     // int maxMesgQLen = 0;
     // int maxTaskQLen = 0;
 
@@ -385,14 +387,16 @@ void *PacketTXRX::loopTXRX(int tid)
     char* rx_cur_buffer_ptr = rx_buffer_ptr;
     int* rx_cur_buffer_status_ptr = rx_buffer_status_ptr;
     int rx_offset = 0;
-    int ant_id, frame_id, symbol_id;
+    int frame_id;
 
 
+#if 0
     // walk through all the pages
     double temp;
     for (int i = 0; i < 20; i++) {
         temp = rx_frame_start[i * 512];
     }
+#endif
 
 
     // TX pointers
@@ -447,8 +451,8 @@ void *PacketTXRX::loopTXRX(int tid)
             // read information from received packet 
             struct Packet *pkt = (struct Packet *)rx_cur_buffer_ptr;
             frame_id = pkt->frame_id;
-            symbol_id = pkt->symbol_id;
-            ant_id = pkt->ant_id;
+            // int symbol_id = pkt->symbol_id;
+            // int ant_id = pkt->ant_id;
             // printf("RX thread %d received frame %d subframe %d, ant %d\n", tid, frame_id, symbol_id, ant_id);
             if (frame_id > prev_frame_id) {
                 *(rx_frame_start + frame_id) = get_time();
@@ -506,10 +510,10 @@ void *PacketTXRX::loopTXRX(int tid)
                 
                 struct Packet *pkt = (struct Packet *)rx_cur_buffer_ptr;
                 frame_id = pkt->frame_id;
-                symbol_id = pkt->symbol_id;
-                ant_id = pkt->ant_id;
 
             #if MEASURE_TIME
+                // int symbol_id = pkt->symbol_id;
+                // int ant_id = pkt->ant_id;
                 // printf("RX thread %d received frame %d subframe %d, ant %d offset %d\n", tid, frame_id, symbol_id, ant_id, rx_offset);
                 // printf("RX thread %d received frame %d subframe %d, ant %d offset %d, buffer status %d %d ptr_offset %d\n", 
                     // tid, frame_id, symbol_id, ant_id, rx_offset, *(rx_buffer_status_ptr+1424), *(rx_cur_buffer_status_ptr+1), rx_cur_buffer_status_ptr - rx_buffer_status_ptr);

--- a/src/millipede/txrx/txrx_DPDK.cpp
+++ b/src/millipede/txrx/txrx_DPDK.cpp
@@ -535,11 +535,11 @@ void* PacketTXRX::loopRecv_DPDK(void *in_context)
 
         #if MEASURE_TIME
             // read information from received packet
-            int ant_id, frame_id, subframe_id, cell_id;
-            frame_id = *((int *)cur_ptr_buffer);
-            subframe_id = *((int *)cur_ptr_buffer + 1);
-            // cell_id = *((int *)cur_ptr_buffer + 2);
-            ant_id = *((int *)cur_ptr_buffer + 3);
+	    struct Packet *pkt = (struct Packet *)cur_buffer_ptr;
+	    int frame_id = pkt->frame_id;
+	    int subframe_id = pkt->symbol_id;
+	    // int cell_id = pkt->cell_id;
+	    int ant_id = pkt->ant_id;
             // printf("RX thread %d received frame %d subframe %d, ant %d\n", tid, frame_id, subframe_id, ant_id);
             if (frame_id > prev_frame_id) {
                 *(frame_start + frame_id) = get_time();


### PR DESCRIPTION
more places.  Rearrange expression of how multiple queues are
checked and work is assigned.