### PR TITLE
Change the allocation of "two-dimensional arrays". Rather than

### DIFF
--- a/simulator/receiver.cpp
+++ b/simulator/receiver.cpp
@@ -56,15 +56,15 @@ Receiver::~Receiver()
 }
 
 
-std::vector<pthread_t> Receiver::startRecv(char** in_buffer, int** in_buffer_status, int in_buffer_frame_num, long long in_buffer_length, double **in_frame_start)
+std::vector<pthread_t> Receiver::startRecv(Table<char> &in_buffer, Table<int> &in_buffer_status, int in_buffer_frame_num, long long in_buffer_length, Table<double> &in_frame_start)
 {
     // check length
     buffer_frame_num_ = in_buffer_frame_num;
     // assert(in_buffer_length == packet_length * buffer_frame_num_); // should be integer
     buffer_length_ = in_buffer_length;
-    buffer_ = in_buffer;  // for save data
-    buffer_status_ = in_buffer_status; // for save status
-    frame_start_ = in_frame_start;
+    buffer_ = &in_buffer;  // for save data
+    buffer_status_ = &in_buffer_status; // for save status
+    frame_start_ = &in_frame_start;
 
     // core_id_ = in_core_id;
     printf("start Recv thread\n");
@@ -180,11 +180,11 @@ void *Receiver::loopRecv(int tid)
     // moodycamel::ProducerToken *local_ptok = new moodycamel::ProducerToken(*message_queue_);
     moodycamel::ProducerToken *local_ptok = rx_ptoks_[tid];
 
-    char *buffer_ptr = buffer_[tid];
-    int *buffer_status_ptr = buffer_status_[tid];
+    char *buffer_ptr = (*buffer_)[tid];
+    int *buffer_status_ptr = (*buffer_status_)[tid];
     long long buffer_length = buffer_length_;
     int buffer_frame_num = buffer_frame_num_;
-    double *frame_start = frame_start_[tid];
+    double *frame_start = (*frame_start_)[tid];
 
 #if 0
     // walk through all the pages

--- a/simulator/receiver.hpp
+++ b/simulator/receiver.hpp
@@ -105,7 +105,7 @@ public:
      * in_buffer_length: size of ring buffer
      * in_core_id: attach socket threads to {in_core_id, ..., in_core_id + RX_THREAD_NUM - 1}
     */ 
-    std::vector<pthread_t> startRecv(char** in_buffer, int** in_buffer_status, int in_buffer_frame_num, long long in_buffer_length, double **in_frame_start);
+    std::vector<pthread_t> startRecv(Table<char> &in_buffer, Table<int> &in_buffer_status, int in_buffer_frame_num, long long in_buffer_length, Table<double> &in_frame_start);
     
     /**
      * receive thread
@@ -134,8 +134,8 @@ private:
     pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
     pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 
-    char** buffer_;
-    int** buffer_status_;
+    Table<char> *buffer_;
+    Table <int> *buffer_status_;
     long long buffer_length_;
     int buffer_frame_num_;
 
@@ -148,7 +148,7 @@ private:
     int rx_thread_num_;
     int tx_thread_num_;
 
-    double **frame_start_;
+    Table<double> *frame_start_;
     // pointer of message_queue_
     moodycamel::ConcurrentQueue<Event_data> *message_queue_;
     moodycamel::ConcurrentQueue<Event_data> *task_queue_;

--- a/simulator/sender.cpp
+++ b/simulator/sender.cpp
@@ -77,7 +77,7 @@ socket_num(in_thread_num), core_offset(in_core_offset), delay(in_delay)
     max_subframe_id = downlink_mode ? UE_NUM : subframe_num_perframe;
     max_length_ = BUFFER_FRAME_NUM * max_subframe_id * BS_ANT_NUM;
 
-    alloc_buffer_2d(&packet_count_per_subframe, BUFFER_FRAME_NUM, max_subframe_id, 64, 1);
+    packet_count_per_subframe.calloc(BUFFER_FRAME_NUM, max_subframe_id, 64);
     alloc_buffer_1d(&packet_count_per_frame, BUFFER_FRAME_NUM, 64, 1);
 
     socket_ = new int[socket_num];
@@ -135,9 +135,9 @@ socket_num(in_thread_num), core_offset(in_core_offset), delay(in_delay)
     }
 
     int IQ_data_size = subframe_num_perframe * BS_ANT_NUM;
-    alloc_buffer_2d(&IQ_data, IQ_data_size, OFDM_FRAME_LEN * 2, 64, 1);
-    alloc_buffer_2d(&IQ_data_coded, IQ_data_size, OFDM_FRAME_LEN * 2, 64, 1);
-    alloc_buffer_2d(&trans_buffer_, max_length_, buffer_length, 64, 1);
+    IQ_data.calloc(IQ_data_size, OFDM_FRAME_LEN * 2, 64);
+    IQ_data_coded.calloc(IQ_data_size, OFDM_FRAME_LEN * 2, 64);
+    trans_buffer_.calloc(max_length_, buffer_length, 64);
     
     /* read from file */
     std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
@@ -167,12 +167,8 @@ socket_num(in_thread_num), core_offset(in_core_offset), delay(in_delay)
 
 Sender::~Sender()
 {
-    for(int i = 0; i < subframe_num_perframe * BS_ANT_NUM; i++) {
-        delete[] IQ_data_coded[i];
-        delete[] IQ_data[i];
-    }
-    delete[] IQ_data;
-    delete[] IQ_data_coded;
+    IQ_data_coded.free();
+    IQ_data.free();
 
     delete[] socket_;
     delete[] context;

--- a/simulator/sender.hpp
+++ b/simulator/sender.hpp
@@ -95,7 +95,7 @@ private:
     // First dimension: BUFFER_FRAME_NUM * subframe_num_perframe * BS_ANT_NUM
     // Second dimension: buffer_length (real and imag)
     // std::vector<std::vector<char,boost::alignment::aligned_allocator<char, 64>>> trans_buffer_;
-    char **trans_buffer_;
+    Table<char> trans_buffer_;
     int cur_ptr_;
     int buffer_len_;
     pthread_mutex_t lock_;
@@ -114,8 +114,8 @@ private:
 
     // First dimension: subframe_num_perframe * BS_ANT_NUM
     // Second dimension: OFDM_FRAME_LEN * 2 (real and imag)
-    float **IQ_data;
-    ushort **IQ_data_coded;
+    Table<float> IQ_data;
+    Table<ushort> IQ_data_coded;
 
     int thread_num;
     int socket_num;
@@ -124,7 +124,7 @@ private:
     int delay;
     EventHandlerContext<Sender> *context;
 
-    int **packet_count_per_subframe;
+    Table<int> packet_count_per_subframe;
     int *packet_count_per_frame;
 
     double *frame_start;

--- a/simulator/simulator.cpp
+++ b/simulator/simulator.cpp
@@ -236,13 +236,13 @@ void Simulator::initialize_uplink_buffers()
 
     socket_buffer_size_ = (long long) packet_length * subframe_num_perframe * BS_ANT_NUM * SOCKET_BUFFER_FRAME_NUM; 
     socket_buffer_status_size_ = subframe_num_perframe * BS_ANT_NUM * SOCKET_BUFFER_FRAME_NUM;
-    alloc_buffer_2d(&socket_buffer_, SOCKET_RX_THREAD_NUM, socket_buffer_size_, 64, 0);
-    alloc_buffer_2d(&socket_buffer_status_, SOCKET_RX_THREAD_NUM, socket_buffer_status_size_, 64, 1);
+    socket_buffer_.malloc(SOCKET_RX_THREAD_NUM, socket_buffer_size_, 64);
+    socket_buffer_status_.calloc(SOCKET_RX_THREAD_NUM, socket_buffer_status_size_, 64);
     
     /* initilize all uplink status checkers */
     alloc_buffer_1d(&rx_counter_packets_, TASK_BUFFER_FRAME_NUM, 64, 1);
 
-    alloc_buffer_2d(&frame_start, SOCKET_RX_THREAD_NUM, 10240, 4096, 1);
+    frame_start.calloc(SOCKET_RX_THREAD_NUM, 10240, 4096);
     alloc_buffer_1d(&frame_start_receive, 10240, 4096, 1);
     alloc_buffer_1d(&frame_end_receive, 10240, 4096, 1);
     alloc_buffer_1d(&frame_start_tx, 10240, 4096, 1);
@@ -256,12 +256,12 @@ void Simulator::free_uplink_buffers()
 {
     // free_buffer_1d(&pilots_);
 
-    free_buffer_2d(&socket_buffer_, SOCKET_RX_THREAD_NUM);
-    free_buffer_2d(&socket_buffer_status_, SOCKET_RX_THREAD_NUM);
+    socket_buffer_.free();
+    socket_buffer_status_.free();
 
     free_buffer_1d(&rx_counter_packets_);
 
-    free_buffer_2d(&frame_start, SOCKET_RX_THREAD_NUM);
+    frame_start.free();
     free_buffer_1d(&frame_start_receive);
     free_buffer_1d(&frame_end_receive);
     free_buffer_1d(&frame_start_tx);

--- a/simulator/simulator.hpp
+++ b/simulator/simulator.hpp
@@ -95,7 +95,7 @@ private:
     int demul_block_size, demul_block_num;
 
     /* lookup table for 16 QAM, real and imag */
-    float **qam16_table_;
+    Table<float> qam16_table_;
     // float *pilots_;
     Config *cfg_;
     int max_equaled_frame = 0;
@@ -121,8 +121,8 @@ private:
     // int *socket_buffer_status_[SOCKET_RX_THREAD_NUM];
     // SocketBuffer socket_buffer_[SOCKET_RX_THREAD_NUM];
 
-    char **socket_buffer_;
-    int **socket_buffer_status_;
+    Table<char> socket_buffer_;
+    Table<int> socket_buffer_status_;
     long long socket_buffer_size_;
     int socket_buffer_status_size_;
     
@@ -149,7 +149,7 @@ private:
     /*****************************************************
      * Timestamps and counters used in worker threads 
      *****************************************************/ 
-    double **frame_start;
+    Table<double> frame_start;
     double *frame_start_receive;
     double *frame_end_receive;
     double *frame_start_tx;

--- a/src/common/buffer.hpp
+++ b/src/common/buffer.hpp
@@ -8,6 +8,8 @@
 #ifndef BUFFER_HEAD
 #define BUFFER_HEAD
 
+#include "memory_manage.h"
+
 // boost is required for aligned memory allocation (for SIMD instructions)
 #include <boost/align/aligned_allocator.hpp>
 
@@ -56,10 +58,10 @@ struct RX_stats {
 };
 
 struct FFT_stats {
-    int **task_count;
+    Table<int> task_count;
     int *symbol_pilot_count;
     int *symbol_data_count;
-    bool **data_exist_in_symbol;
+    Table<bool> data_exist_in_symbol;
     int frame_count = 0;
     int max_task_count;
     int max_symbol_pilot_count;
@@ -74,7 +76,7 @@ struct ZF_stats {
 };
 
 struct Data_stats {
-    int **task_count;
+    Table<int> task_count;
     int *symbol_count;
     int frame_count = 0;
     int max_task_count;
@@ -88,16 +90,16 @@ struct FFTBuffer
 {
     // Data before IFFT
     // record TASK_BUFFER_FRAME_NUM entire frames
-    complex_float **FFT_inputs;
-    complex_float **FFT_outputs;
+    Table<complex_float> FFT_inputs;
+    Table<complex_float> FFT_outputs;
 };
 
 struct IFFTBuffer
 {
     // Data before IFFT
     // record TASK_BUFFER_FRAME_NUM entire frames
-    complex_float **IFFT_inputs;
-    complex_float **IFFT_outputs;
+    Table<complex_float> IFFT_inputs;
+    Table<complex_float> IFFT_outputs;
 };
 
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -230,11 +230,11 @@ Config::Config(std::string jsonfile)
 
 #endif
 
-    alloc_buffer_2d(&dl_IQ_data, data_symbol_num_perframe, OFDM_CA_NUM * UE_NUM, 64, 0);
-    alloc_buffer_2d(&dl_IQ_modul, data_symbol_num_perframe, OFDM_CA_NUM * UE_NUM, 64, 0); // used for debug
-    alloc_buffer_2d(&dl_IQ_symbol, data_symbol_num_perframe, sampsPerSymbol, 64, 0); // used for debug
-    alloc_buffer_2d(&ul_IQ_data, ul_data_symbol_num_perframe * UE_NUM, OFDM_DATA_NUM, 64, 0);
-    alloc_buffer_2d(&ul_IQ_modul, ul_data_symbol_num_perframe * UE_NUM, OFDM_CA_NUM, 64, 0);
+    dl_IQ_data.malloc(data_symbol_num_perframe, OFDM_CA_NUM * UE_NUM, 64);
+    dl_IQ_modul.malloc(data_symbol_num_perframe, OFDM_CA_NUM * UE_NUM, 64); // used for debug
+    dl_IQ_symbol.malloc(data_symbol_num_perframe, sampsPerSymbol, 64); // used for debug
+    ul_IQ_data.malloc(ul_data_symbol_num_perframe * UE_NUM, OFDM_DATA_NUM, 64);
+    ul_IQ_modul.malloc(ul_data_symbol_num_perframe * UE_NUM, OFDM_CA_NUM, 64);
 
 
 
@@ -329,11 +329,11 @@ Config::Config(std::string jsonfile)
 Config::~Config()
 {
     free_buffer_1d(&pilots_);
-    free_buffer_2d(&dl_IQ_data, data_symbol_num_perframe);
-    free_buffer_2d(&dl_IQ_modul, data_symbol_num_perframe);
-    free_buffer_2d(&dl_IQ_symbol, data_symbol_num_perframe);
-    free_buffer_2d(&ul_IQ_data, data_symbol_num_perframe * UE_NUM);
-    free_buffer_2d(&ul_IQ_modul, data_symbol_num_perframe * UE_NUM);
+    dl_IQ_data.free();
+    dl_IQ_modul.free();
+    dl_IQ_symbol.free();
+    ul_IQ_data.free();
+    ul_IQ_modul.free();
 }
 
 int Config::getDownlinkPilotId(size_t frame_id, size_t symbol_id)

--- a/src/common/config.hpp
+++ b/src/common/config.hpp
@@ -62,11 +62,11 @@ public:
     std::vector<uint32_t> pilot;
     std::vector<uint32_t> beacon;
     float *pilots_;
-    int8_t **dl_IQ_data;
-    int8_t **ul_IQ_data;
-    complex_float **ul_IQ_modul;
-    complex_float **dl_IQ_modul;
-    std::complex<int16_t> **dl_IQ_symbol;
+    Table<int8_t> dl_IQ_data;
+    Table<int8_t> ul_IQ_data;
+    Table<complex_float> ul_IQ_modul;
+    Table<complex_float> dl_IQ_modul;
+    Table<std::complex<int16_t>> dl_IQ_symbol;
     
     double freq;
     double bbf_ratio;

--- a/src/common/modulation.cpp
+++ b/src/common/modulation.cpp
@@ -52,25 +52,23 @@ void print128_epi8(__m128i var)
   */
 
 
-float **init_modulation_table(size_t mod_order)
+void init_modulation_table(Table<float> &mod_table, size_t mod_order)
 {
-    float **mod_table;
     switch(mod_order) {
         case 2:
-            mod_table = init_qpsk_table();
+            init_qpsk_table(mod_table);
             break;
         case 4:
-            mod_table = init_qam16_table();
+            init_qam16_table(mod_table);
             break;
         case 6:
-            mod_table = init_qam64_table();
+            init_qam64_table(mod_table);
             break;
         default: {
             printf("Modulation order not supported, use default value 4\n");
-            mod_table = init_qam16_table();
+            init_qam16_table(mod_table);
         }
     }
-    return mod_table;
 }
 
 
@@ -81,17 +79,15 @@ float **init_modulation_table(size_t mod_order)
   *---------------> I
   *  00  |  10
   */
-float **init_qpsk_table()
+void init_qpsk_table(Table<float>& qpsk_table)
 {
-    float **qpsk_table;
-    alloc_buffer_2d(&qpsk_table, 4, 2, 32, 1);
+    qpsk_table.malloc(4, 2, 32);
     float scale = 1/sqrt(2);
     float mod_qpsk[2] = {-scale, scale};
     for (int i = 0; i < 4; i++) {
         qpsk_table[i][1] = mod_qpsk[i / 2];
         qpsk_table[i][0] = mod_qpsk[i % 2];
     }
-    return qpsk_table;
 }
 
 
@@ -106,7 +102,7 @@ float **init_qpsk_table()
 //   */
 // void init_qam16_table(float **qam16_table)
 // {
-//     alloc_buffer_2d(&qam16_table, 16, 2, 32, 1);
+//     qam16_table.malloc(16, 2, 32);
 //     float scale = 1/sqrt(10);
 //     float mod_16qam[4] = {-3*scale, -1*scale, 3*scale, scale};
 //     for (int i = 0; i < 16; i++) {
@@ -125,10 +121,9 @@ float **init_qpsk_table()
   *  1110  1100  |  0100  0110
   *  1111  1101  |  0101  0111
   */
-float **init_qam16_table()
+void init_qam16_table(Table<float> &qam16_table)
 {
-    float **qam16_table;
-    alloc_buffer_2d(&qam16_table, 16, 2, 32, 1);
+    qam16_table.malloc(16, 2, 32);
     float scale = 1/sqrt(10);
     float mod_16qam[4] = {1 * scale, 3 * scale, (-1) * scale, (-3) * scale};
     for (int i = 0; i < 16; i++) {
@@ -140,7 +135,6 @@ float **init_qam16_table()
       qam16_table[i][1] = mod_16qam[imag_i];
       // printf("%d: (%.3f, %.3f)\n", i, qam16_table[i][0], qam16_table[i][1]);
     }
-    return qam16_table;
 }
 
 
@@ -159,10 +153,9 @@ float **init_qam16_table()
   *  111111  111101  110101  110111  |  010111  010101  011101  011111
   */
 
-float **init_qam64_table()
+void init_qam64_table(Table<float> &qam64_table)
 {
-    float **qam64_table;
-    alloc_buffer_2d(&qam64_table, 64, 2, 32, 1);
+    qam64_table.malloc(64, 2, 32);
     float scale = 1/sqrt(42);
     float mod_64qam[8] = {3 * scale, 1 * scale, 5 * scale, 7 * scale, (-3) * scale, (-1) * scale, (-5) * scale, (-7) * scale};
     for (int i = 0; i < 64; i++) {
@@ -173,7 +166,6 @@ float **init_qam64_table()
       qam64_table[i][0] = mod_64qam[real_i];
       qam64_table[i][1] = mod_64qam[imag_i];
     }
-    return qam64_table;
 }
 
 
@@ -193,7 +185,7 @@ complex_float mod_single(int x, float **mod_table)
     return re;
 }
 
-complex_float mod_single_uint8(uint8_t x, float **mod_table) 
+complex_float mod_single_uint8(uint8_t x, Table<float> &mod_table) 
 {
     complex_float re;
     re.re = mod_table[x][0];

--- a/src/common/modulation.hpp
+++ b/src/common/modulation.hpp
@@ -26,15 +26,15 @@
 
 // using namespace arma;
 // using namespace std;
-float **init_modulation_table(size_t mod_order);
-float **init_qpsk_table();
-// void init_qam16_table(float **qam16_table);
-float **init_qam16_table();
-float **init_qam64_table();
+void init_modulation_table(Table<float> &table, size_t mod_order);
+void init_qpsk_table(Table<float> &table);
+// void init_qam16_table(Table<float> &table);
+void init_qam16_table(Table<float> &table);
+void init_qam64_table(Table<float> &table);
 
 
 complex_float mod_single(int x, float **mod_table);
-complex_float mod_single_uint8(uint8_t x, float **mod_table);
+complex_float mod_single_uint8(uint8_t x, Table<float> &mod_table);
 
 void demod_16qam_hard_loop(float *vec_in, uint8_t *vec_out, int num);
 void demod_16qam_hard_sse(float *vec_in, uint8_t *vec_out, int num);

--- a/src/millipede/dodemul.cpp
+++ b/src/millipede/dodemul.cpp
@@ -7,9 +7,16 @@
 
 using namespace arma;
 DoDemul::DoDemul(Config *cfg, int in_tid, int in_demul_block_size, int in_transpose_block_size,
-        moodycamel::ConcurrentQueue<Event_data> *in_complete_task_queue, moodycamel::ProducerToken *in_task_ptok,
-        complex_float **in_data_buffer, complex_float **in_precoder_buffer, complex_float **in_equal_buffer, uint8_t **in_demod_hard_buffer,
-        int8_t **in_demod_soft_buffer, Stats *in_stats_manager)
+		 moodycamel::ConcurrentQueue<Event_data> *in_complete_task_queue, moodycamel::ProducerToken *in_task_ptok,
+		 Table<complex_float> &in_data_buffer, Table<complex_float> &in_precoder_buffer,
+		 Table<complex_float> &in_equal_buffer, Table<uint8_t> &in_demod_hard_buffer,
+		 Table<int8_t> &in_demod_soft_buffer, Stats *in_stats_manager)
+  : data_buffer_(in_data_buffer)
+  , precoder_buffer_(in_precoder_buffer)
+  , equal_buffer_(in_equal_buffer)
+  , demod_hard_buffer_(in_demod_hard_buffer)
+  , demod_soft_buffer_(in_demod_soft_buffer)
+  , Demul_task_duration(in_stats_manager->demul_stats_worker.task_duration)
 {
     config_ = cfg;
     BS_ANT_NUM = cfg->BS_ANT_NUM;
@@ -24,13 +31,6 @@ DoDemul::DoDemul(Config *cfg, int in_tid, int in_demul_block_size, int in_transp
     complete_task_queue_ = in_complete_task_queue;
     task_ptok = in_task_ptok;
 
-    data_buffer_ = in_data_buffer;
-    precoder_buffer_ = in_precoder_buffer;
-    equal_buffer_ = in_equal_buffer;
-    demod_hard_buffer_ = in_demod_hard_buffer;
-    demod_soft_buffer_ = in_demod_soft_buffer;
-
-    Demul_task_duration = in_stats_manager->demul_stats_worker.task_duration;
     Demul_task_count = in_stats_manager->demul_stats_worker.task_count;
     // Demul_task_duration = in_Demul_task_duration;
     // Demul_task_count = in_Demul_task_count;

--- a/src/millipede/dodemul.hpp
+++ b/src/millipede/dodemul.hpp
@@ -27,8 +27,8 @@ class DoDemul
 public:
     DoDemul(Config *cfg, int in_tid, int in_demod_block_size, int in_transpose_block_size,
         moodycamel::ConcurrentQueue<Event_data> *in_complete_task_queue, moodycamel::ProducerToken *in_task_ptok,
-        complex_float **in_data_buffer, complex_float **in_precoder_buffer, complex_float **in_equal_buffer, uint8_t **in_demul_hard_buffer,
-        int8_t **in_demod_soft_buffer, Stats *in_stats_manager);
+	    Table<complex_float> &in_data_buffer, Table<complex_float> &in_precoder_buffer, Table<complex_float> &in_equal_buffer,
+	    Table<uint8_t> &in_demul_hard_buffer, Table<int8_t> &in_demod_soft_buffer, Stats *in_stats_manager);
     ~DoDemul();
 
     /**
@@ -77,13 +77,13 @@ private:
     
 
 
-    complex_float **data_buffer_;
-    complex_float **precoder_buffer_;
-    complex_float **equal_buffer_;
-    uint8_t **demod_hard_buffer_;
-    int8_t **demod_soft_buffer_;
+    Table<complex_float> &data_buffer_;
+    Table<complex_float> &precoder_buffer_;
+    Table<complex_float> &equal_buffer_;
+    Table<uint8_t> &demod_hard_buffer_;
+    Table<int8_t> &demod_soft_buffer_;
 
-    double **Demul_task_duration;
+    Table<double> &Demul_task_duration;
     int *Demul_task_count;
 
     /** 

--- a/src/millipede/dofft.hpp
+++ b/src/millipede/dofft.hpp
@@ -26,8 +26,8 @@ class DoFFT
 public:
     DoFFT(Config *cfg, int in_tid, int in_transpose_block_size, 
         moodycamel::ConcurrentQueue<Event_data> *in_complete_task_queue, moodycamel::ProducerToken *in_task_ptok,
-        char **in_socket_buffer, int **in_socket_buffer_status, complex_float **in_data_buffer_, complex_float **in_csi_buffer, float *in_pilots,
-        complex_float **in_dl_ifft_buffer, char *in_dl_socket_buffer, 
+	Table<char> &in_socket_buffer, Table<int> &in_socket_buffer_status, Table<complex_float> &in_data_buffer, Table<complex_float> &in_csi_buffer, float *in_pilots,
+        Table<complex_float> &in_dl_ifft_buffer, char *in_dl_socket_buffer, 
         Stats *in_stats_manager);
     ~DoFFT();
 
@@ -108,22 +108,22 @@ private:
     moodycamel::ConcurrentQueue<Event_data> *complete_task_queue_;
     moodycamel::ProducerToken *task_ptok;
 
-    char **socket_buffer_;
-    int **socket_buffer_status_;
-    complex_float **data_buffer_;
-    complex_float **csi_buffer_;
+    Table<char> &socket_buffer_;
+    Table<int> &socket_buffer_status_;
+    Table<complex_float> &data_buffer_;
+    Table<complex_float> &csi_buffer_;
     float *pilots_;
 
     char *dl_socket_buffer_;;
-    complex_float **dl_ifft_buffer_;
+    Table<complex_float> &dl_ifft_buffer_;
 
 
     // int packet_length;
-    double **FFT_task_duration;
-    double **CSI_task_duration;
+    Table<double> *FFT_task_duration;
+    Table<double> *CSI_task_duration;
     int *FFT_task_count;
     int *CSI_task_count;
-    double **IFFT_task_duration;
+    Table<double> *IFFT_task_duration;
     int *IFFT_task_count;
 
     FFTBuffer fft_buffer_;

--- a/src/millipede/doprecode.hpp
+++ b/src/millipede/doprecode.hpp
@@ -28,8 +28,8 @@ class DoPrecode
 public:
     DoPrecode(Config *cfg, int in_tid, int in_demul_block_size, int in_transpose_block_size,
         moodycamel::ConcurrentQueue<Event_data> *in_complete_task_queue, moodycamel::ProducerToken *in_task_ptok,
-        complex_float **in_dl_modulated_buffer, complex_float **in_precoder_buffer, complex_float **in_dl_precoded_data_buffer, 
-        complex_float **in_dl_ifft_buffer, int8_t **in_dl_IQ_data, int8_t **in_dl_encoded_data,
+	Table<complex_float> &in_dl_modulated_buffer, Table<complex_float> &in_precoder_buffer, Table<complex_float> &in_dl_precoded_data_buffer, 
+        Table<complex_float> &in_dl_ifft_buffer, Table<int8_t> &in_dl_IQ_data, Table<int8_t> &in_dl_encoded_data,
         Stats *in_stats_manager);
     ~DoPrecode();
 
@@ -76,14 +76,14 @@ private:
     moodycamel::ConcurrentQueue<Event_data> *complete_task_queue_;
     moodycamel::ProducerToken *task_ptok;
     
-    complex_float **dl_modulated_buffer_;
-    complex_float **precoder_buffer_;
-    complex_float **dl_precoded_data_buffer_;
-    complex_float **dl_ifft_buffer_;
-    int8_t **dl_IQ_data;
-    float **qam_table;
+    Table<complex_float> &dl_modulated_buffer_;
+    Table<complex_float> &precoder_buffer_;
+    Table<complex_float> &dl_precoded_data_buffer_;
+    Table<complex_float> &dl_ifft_buffer_;
+    Table<int8_t> &dl_IQ_data;
+    Table<float> qam_table;
 
-    double **Precode_task_duration;
+    Table<double> &Precode_task_duration;
     int *Precode_task_count;
 
     complex_float *modulated_buffer_temp;

--- a/src/millipede/dozf.hpp
+++ b/src/millipede/dozf.hpp
@@ -26,7 +26,7 @@ class DoZF
 public:
     DoZF(Config *cfg, int in_tid, int in_zf_block_size, int in_transpose_block_size,
         moodycamel::ConcurrentQueue<Event_data> *in_complete_task_queue, moodycamel::ProducerToken *in_task_ptok,
-        complex_float **in_csi_buffer, complex_float **in_precoder_buffer, complex_float **in_dl_precoder_buffer, complex_float **in_recip_buffer, complex_float **in_pred_csi_buffer, 
+        Table<complex_float> &in_csi_buffer, Table<complex_float> &in_precoder_buffer, Table<complex_float> &in_dl_precoder_buffer, Table<complex_float> &in_recip_buffer, Table<complex_float> &in_pred_csi_buffer, 
         Stats *in_stats_manager);
     ~DoZF();
 
@@ -86,13 +86,13 @@ private:
     moodycamel::ConcurrentQueue<Event_data> *complete_task_queue_;
     moodycamel::ProducerToken *task_ptok;
 
-    complex_float **csi_buffer_;
-    complex_float **precoder_buffer_;
-    complex_float **dl_precoder_buffer_;
-    complex_float **recip_buffer_;
-    complex_float **pred_csi_buffer_;
+    Table<complex_float> csi_buffer_;
+    Table<complex_float> precoder_buffer_;
+    Table<complex_float> dl_precoder_buffer_;
+    Table<complex_float> recip_buffer_;
+    Table<complex_float> pred_csi_buffer_;
 
-    double **ZF_task_duration;
+  Table<double> *ZF_task_duration;
     int *ZF_task_count;
 
     /** 

--- a/src/millipede/millipede.cpp
+++ b/src/millipede/millipede.cpp
@@ -496,16 +496,16 @@ void *Millipede::worker(int tid)
     DoZF *computeZF = new DoZF(cfg_, tid, zf_block_size, transpose_block_size, &complete_task_queue_, task_ptok_ptr,
         csi_buffer_, precoder_buffer_, dl_precoder_buffer_, recip_buffer_,  pred_csi_buffer_, stats_manager_);
 
-    DoDemul *computeDemul = new DoDemul(cfg_, tid, demul_block_size, transpose_block_size, &(complete_task_queue_), task_ptok_ptr,
+    DoDemul *computeDemul = new DoDemul(cfg_, tid, demul_block_size, transpose_block_size, &complete_task_queue_, task_ptok_ptr,
         data_buffer_, precoder_buffer_, equal_buffer_, demod_hard_buffer_, demod_soft_buffer_, stats_manager_);
 
-    DoPrecode *computePrecode = new DoPrecode(cfg_, tid, demul_block_size, transpose_block_size, &(complete_task_queue_), task_ptok_ptr,
-        dl_modulated_buffer_, dl_precoder_buffer_, dl_precoded_data_buffer_, dl_ifft_buffer_, dl_IQ_data, dl_encoded_buffer_,
+    DoPrecode *computePrecode = new DoPrecode(cfg_, tid, demul_block_size, transpose_block_size, &complete_task_queue_, task_ptok_ptr,
+        dl_modulated_buffer_, dl_precoder_buffer_, dl_precoded_data_buffer_, dl_ifft_buffer_, *dl_IQ_data, dl_encoded_buffer_,
         stats_manager_);
 
     #ifdef USE_LDPC
-    DoCoding *computeCoding = new DoCoding(cfg_, tid, &(complete_task_queue_), task_ptok_ptr,
-        dl_IQ_data, dl_encoded_buffer_, demod_soft_buffer_, decoded_buffer_, 
+    DoCoding *computeCoding = new DoCoding(cfg_, tid, &complete_task_queue_, task_ptok_ptr,
+        *dl_IQ_data, dl_encoded_buffer_, demod_soft_buffer_, decoded_buffer_, 
         stats_manager_);
     #endif
 
@@ -605,7 +605,7 @@ void* Millipede::worker_fft(int tid)
     moodycamel::ProducerToken *task_ptok_ptr = task_ptoks_ptr[tid];
 
     /* initialize FFT operator */
-    DoFFT* computeFFT = new DoFFT(cfg_, tid, transpose_block_size, &(complete_task_queue_), task_ptok_ptr,
+    DoFFT* computeFFT = new DoFFT(cfg_, tid, transpose_block_size, &complete_task_queue_, task_ptok_ptr,
         socket_buffer_, socket_buffer_status_, data_buffer_, csi_buffer_, pilots_,
         dl_ifft_buffer_, dl_socket_buffer_, stats_manager_);
 
@@ -632,7 +632,7 @@ void* Millipede::worker_zf(int tid)
     moodycamel::ProducerToken *task_ptok_ptr = task_ptoks_ptr[tid];
 
     /* initialize ZF operator */
-    DoZF *computeZF = new DoZF(cfg_, tid, zf_block_size, transpose_block_size, &(complete_task_queue_), task_ptok_ptr,
+    DoZF *computeZF = new DoZF(cfg_, tid, zf_block_size, transpose_block_size, &complete_task_queue_, task_ptok_ptr,
         csi_buffer_, precoder_buffer_, dl_precoder_buffer_, recip_buffer_,  pred_csi_buffer_, stats_manager_);
 
 
@@ -653,13 +653,13 @@ void* Millipede::worker_demul(int tid)
     moodycamel::ProducerToken *task_ptok_ptr = task_ptoks_ptr[tid];
 
     /* initialize Demul operator */
-    DoDemul *computeDemul = new DoDemul(cfg_, tid, demul_block_size, transpose_block_size, &(complete_task_queue_), task_ptok_ptr,
+    DoDemul *computeDemul = new DoDemul(cfg_, tid, demul_block_size, transpose_block_size, &complete_task_queue_, task_ptok_ptr,
         data_buffer_, precoder_buffer_, equal_buffer_, demod_hard_buffer_, demod_soft_buffer_, stats_manager_);
 
 
     /* initialize Precode operator */
-    DoPrecode *computePrecode = new DoPrecode(cfg_, tid, demul_block_size, transpose_block_size, &(complete_task_queue_), task_ptok_ptr,
-        dl_modulated_buffer_, dl_precoder_buffer_, dl_precoded_data_buffer_, dl_ifft_buffer_, dl_IQ_data, dl_encoded_buffer_,
+    DoPrecode *computePrecode = new DoPrecode(cfg_, tid, demul_block_size, transpose_block_size, &complete_task_queue_, task_ptok_ptr,
+        dl_modulated_buffer_, dl_precoder_buffer_, dl_precoded_data_buffer_, dl_ifft_buffer_, *dl_IQ_data, dl_encoded_buffer_,
         stats_manager_);
 
 
@@ -1053,7 +1053,7 @@ void Millipede::print_per_task_done(int task_type, int frame_id, int subframe_id
 void Millipede::initialize_vars_from_cfg(Config *cfg)
 {
     pilots_ = cfg->pilots_;
-    dl_IQ_data = cfg->dl_IQ_data;
+    dl_IQ_data = &cfg->dl_IQ_data;
 
 #if DEBUG_PRINT_PILOT
     cout<<"Pilot data"<<endl;
@@ -1134,16 +1134,16 @@ void Millipede::initialize_uplink_buffers()
     socket_buffer_size_ = (long long) packet_length * subframe_num_perframe * BS_ANT_NUM * SOCKET_BUFFER_FRAME_NUM; 
     socket_buffer_status_size_ = subframe_num_perframe * BS_ANT_NUM * SOCKET_BUFFER_FRAME_NUM;
     printf("socket_buffer_size %lld, socket_buffer_status_size %d\n", socket_buffer_size_, socket_buffer_status_size_);
-    alloc_buffer_2d(&socket_buffer_, SOCKET_RX_THREAD_NUM, socket_buffer_size_, 64, 0);
-    alloc_buffer_2d(&socket_buffer_status_, SOCKET_RX_THREAD_NUM, socket_buffer_status_size_, 64, 1);
-    alloc_buffer_2d(&csi_buffer_ , PILOT_NUM * TASK_BUFFER_FRAME_NUM, BS_ANT_NUM * OFDM_DATA_NUM, 64, 0);
-    alloc_buffer_2d(&data_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, BS_ANT_NUM * OFDM_DATA_NUM, 64, 0);
-    alloc_buffer_2d(&pred_csi_buffer_ , OFDM_DATA_NUM, BS_ANT_NUM * UE_NUM, 64, 0);
-    alloc_buffer_2d(&precoder_buffer_ , OFDM_DATA_NUM * TASK_BUFFER_FRAME_NUM, UE_NUM * BS_ANT_NUM, 64, 0);
-    alloc_buffer_2d(&equal_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_DATA_NUM * UE_NUM, 64, 0);
-    alloc_buffer_2d(&demod_hard_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_DATA_NUM * UE_NUM, 64, 0);
-    alloc_buffer_2d(&demod_soft_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, mod_type * OFDM_DATA_NUM * UE_NUM, 64, 0);
-    alloc_buffer_2d(&decoded_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_DATA_NUM * UE_NUM, 64, 0);
+    socket_buffer_.malloc(SOCKET_RX_THREAD_NUM, socket_buffer_size_, 64);
+    socket_buffer_status_.calloc(SOCKET_RX_THREAD_NUM, socket_buffer_status_size_, 64);
+    csi_buffer_.malloc(PILOT_NUM * TASK_BUFFER_FRAME_NUM, BS_ANT_NUM * OFDM_DATA_NUM, 64);
+    data_buffer_.malloc(data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, BS_ANT_NUM * OFDM_DATA_NUM, 64);
+    pred_csi_buffer_.malloc(OFDM_DATA_NUM, BS_ANT_NUM * UE_NUM, 64);
+    precoder_buffer_.malloc(OFDM_DATA_NUM * TASK_BUFFER_FRAME_NUM, UE_NUM * BS_ANT_NUM, 64);
+    equal_buffer_.malloc(data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_DATA_NUM * UE_NUM, 64);
+    demod_hard_buffer_.malloc(data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_DATA_NUM * UE_NUM, 64);
+    demod_soft_buffer_.malloc(data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, mod_type * OFDM_DATA_NUM * UE_NUM, 64);
+    decoded_buffer_.malloc(data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_DATA_NUM * UE_NUM, 64);
     
     int max_packet_num_per_frame = downlink_mode ? (BS_ANT_NUM * PILOT_NUM) : (BS_ANT_NUM * (ul_data_subframe_num_perframe + PILOT_NUM));
     rx_stats_.max_task_count = max_packet_num_per_frame;
@@ -1155,8 +1155,8 @@ void Millipede::initialize_uplink_buffers()
     fft_stats_.max_task_count = BS_ANT_NUM;
     fft_stats_.max_symbol_pilot_count = PILOT_NUM;
     fft_stats_.max_symbol_data_count = ul_data_subframe_num_perframe;
-    alloc_buffer_2d(&(fft_stats_.task_count), TASK_BUFFER_FRAME_NUM, subframe_num_perframe, 64, 1);
-    alloc_buffer_2d(&(fft_stats_.data_exist_in_symbol), TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64, 1);
+    fft_stats_.task_count.calloc(TASK_BUFFER_FRAME_NUM, subframe_num_perframe, 64);
+    fft_stats_.data_exist_in_symbol.calloc(TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64);
     alloc_buffer_1d(&(fft_stats_.symbol_pilot_count), TASK_BUFFER_FRAME_NUM, 64, 1);
     alloc_buffer_1d(&(fft_stats_.symbol_data_count), TASK_BUFFER_FRAME_NUM, 64, 1);
 
@@ -1166,16 +1166,16 @@ void Millipede::initialize_uplink_buffers()
 
     demul_stats_.max_task_count = demul_block_num;
     demul_stats_.max_symbol_count = ul_data_subframe_num_perframe;
-    alloc_buffer_2d(&(demul_stats_.task_count), TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64, 1);
-    alloc_buffer_1d(&(demul_stats_.symbol_count), TASK_BUFFER_FRAME_NUM, 64, 1);
+    demul_stats_.task_count.calloc(TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64);
+    alloc_buffer_1d(&demul_stats_.symbol_count, TASK_BUFFER_FRAME_NUM, 64, 1);
 
     decode_stats_.max_task_count = LDPC_config.nblocksInSymbol * UE_NUM;
     decode_stats_.max_symbol_count = ul_data_subframe_num_perframe;
-    alloc_buffer_2d(&(decode_stats_.task_count), TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64, 1);
-    alloc_buffer_1d(&(decode_stats_.symbol_count), TASK_BUFFER_FRAME_NUM, 64, 1);
+    decode_stats_.task_count.calloc(TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64);
+    alloc_buffer_1d(&decode_stats_.symbol_count, TASK_BUFFER_FRAME_NUM, 64, 1);
     
 
-    alloc_buffer_2d(&delay_fft_queue, TASK_BUFFER_FRAME_NUM, subframe_num_perframe * BS_ANT_NUM, 32, 1);
+    delay_fft_queue.calloc(TASK_BUFFER_FRAME_NUM, subframe_num_perframe * BS_ANT_NUM, 32);
     alloc_buffer_1d(&delay_fft_queue_cnt, TASK_BUFFER_FRAME_NUM, 32, 1);
 }
 
@@ -1188,31 +1188,31 @@ void Millipede::initialize_downlink_buffers()
     dl_socket_buffer_status_size_ = data_subframe_num_perframe * BS_ANT_NUM * SOCKET_BUFFER_FRAME_NUM;
     alloc_buffer_1d(&dl_socket_buffer_, dl_socket_buffer_size_, 64, 0);
     alloc_buffer_1d(&dl_socket_buffer_status_, dl_socket_buffer_status_size_, 64, 1);
-    alloc_buffer_2d(&dl_ifft_buffer_, BS_ANT_NUM * data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_CA_NUM, 64, 1);
-    alloc_buffer_2d(&dl_precoded_data_buffer_, data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, BS_ANT_NUM * OFDM_DATA_NUM, 64, 0);
-    alloc_buffer_2d(&dl_modulated_buffer_, data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, UE_NUM * OFDM_DATA_NUM, 64, 0);
-    alloc_buffer_2d(&dl_precoder_buffer_ , OFDM_DATA_NUM * TASK_BUFFER_FRAME_NUM, UE_NUM * BS_ANT_NUM, 64, 0);
-    alloc_buffer_2d(&dl_encoded_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_DATA_NUM * UE_NUM, 64, 0);
-    alloc_buffer_2d(&recip_buffer_ , OFDM_DATA_NUM, BS_ANT_NUM, 64, 0);
+    dl_ifft_buffer_.calloc(BS_ANT_NUM * data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_CA_NUM, 64);
+    dl_precoded_data_buffer_.malloc(data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, BS_ANT_NUM * OFDM_DATA_NUM, 64);
+    dl_modulated_buffer_.malloc(data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, UE_NUM * OFDM_DATA_NUM, 64);
+    dl_precoder_buffer_.malloc(OFDM_DATA_NUM * TASK_BUFFER_FRAME_NUM, UE_NUM * BS_ANT_NUM, 64);
+    dl_encoded_buffer_.malloc(data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM, OFDM_DATA_NUM * UE_NUM, 64);
+    recip_buffer_.malloc(OFDM_DATA_NUM, BS_ANT_NUM, 64);
 
     encode_stats_.max_task_count = LDPC_config.nblocksInSymbol * UE_NUM;
     encode_stats_.max_symbol_count = dl_data_subframe_num_perframe;
-    alloc_buffer_2d(&(encode_stats_.task_count), TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64, 1);
+    encode_stats_.task_count.calloc(TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64);
     alloc_buffer_1d(&(encode_stats_.symbol_count), TASK_BUFFER_FRAME_NUM, 64, 1);
 
     precode_stats_.max_task_count = demul_block_num;
     precode_stats_.max_symbol_count = dl_data_subframe_num_perframe;
-    alloc_buffer_2d(&(precode_stats_.task_count), TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64, 1);
+    precode_stats_.task_count.calloc(TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64);
     alloc_buffer_1d(&(precode_stats_.symbol_count), TASK_BUFFER_FRAME_NUM, 64, 1);
 
     ifft_stats_.max_task_count = BS_ANT_NUM;
     ifft_stats_.max_symbol_count = dl_data_subframe_num_perframe;
-    alloc_buffer_2d(&(ifft_stats_.task_count), TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64, 1);
+    ifft_stats_.task_count.calloc(TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64);
     alloc_buffer_1d(&(ifft_stats_.symbol_count), TASK_BUFFER_FRAME_NUM, 64, 1);
 
     tx_stats_.max_task_count = BS_ANT_NUM;
     tx_stats_.max_symbol_count = dl_data_subframe_num_perframe;
-    alloc_buffer_2d(&(tx_stats_.task_count), TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64, 1);
+    tx_stats_.task_count.calloc(TASK_BUFFER_FRAME_NUM, data_subframe_num_perframe, 64);
     alloc_buffer_1d(&(tx_stats_.symbol_count), TASK_BUFFER_FRAME_NUM, 64, 1);
 }
 
@@ -1220,32 +1220,32 @@ void Millipede::initialize_downlink_buffers()
 void Millipede::free_uplink_buffers()
 {
     //free_buffer_1d(&pilots_);
-    free_buffer_2d(&socket_buffer_, SOCKET_RX_THREAD_NUM);
-    free_buffer_2d(&socket_buffer_status_, SOCKET_RX_THREAD_NUM);
-    free_buffer_2d(&csi_buffer_, UE_NUM * TASK_BUFFER_FRAME_NUM);
-    free_buffer_2d(&data_buffer_, data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM);
-    free_buffer_2d(&pred_csi_buffer_ , OFDM_DATA_NUM);
-    free_buffer_2d(&precoder_buffer_ , OFDM_DATA_NUM * TASK_BUFFER_FRAME_NUM);
-    free_buffer_2d(&equal_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM);
-    free_buffer_2d(&demod_hard_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM);
-    free_buffer_2d(&demod_soft_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM);
-    free_buffer_2d(&decoded_buffer_ , data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM);
+    socket_buffer_.free();
+    socket_buffer_status_.free();
+    csi_buffer_.free();
+    data_buffer_.free();
+    pred_csi_buffer_.free();
+    precoder_buffer_.free();
+    equal_buffer_.free();
+    demod_hard_buffer_.free();
+    demod_soft_buffer_.free();
+    decoded_buffer_.free();
 
     free_buffer_1d(&(rx_stats_.task_count));
     free_buffer_1d(&(rx_stats_.task_pilot_count));
     free_buffer_1d(&(rx_stats_.fft_created_count));
-    free_buffer_2d(&(fft_stats_.task_count), TASK_BUFFER_FRAME_NUM);
-    free_buffer_2d(&(fft_stats_.data_exist_in_symbol), TASK_BUFFER_FRAME_NUM);
+    fft_stats_.task_count.free();
+    fft_stats_.data_exist_in_symbol.free();
     free_buffer_1d(&(fft_stats_.symbol_pilot_count));
     free_buffer_1d(&(fft_stats_.symbol_data_count));
     free_buffer_1d(&(zf_stats_.task_count));
     free_buffer_1d(&(zf_stats_.precoder_exist_in_frame));
-    free_buffer_2d(&(demul_stats_.task_count), TASK_BUFFER_FRAME_NUM);
+    demul_stats_.task_count.free();
     free_buffer_1d(&(demul_stats_.symbol_count));
-    free_buffer_2d(&(decode_stats_.task_count), TASK_BUFFER_FRAME_NUM);
+    decode_stats_.task_count.free();
     free_buffer_1d(&(decode_stats_.symbol_count));
 
-    free_buffer_2d(&delay_fft_queue, TASK_BUFFER_FRAME_NUM);
+    delay_fft_queue.free();
     free_buffer_1d(&delay_fft_queue_cnt);
 }
 
@@ -1254,18 +1254,18 @@ void Millipede::free_downlink_buffers()
     free_buffer_1d(&dl_socket_buffer_);
     free_buffer_1d(&dl_socket_buffer_status_);
 
-    free_buffer_2d(&dl_ifft_buffer_, BS_ANT_NUM * data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM);
-    free_buffer_2d(&dl_precoded_data_buffer_, data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM);
-    free_buffer_2d(&dl_modulated_buffer_, data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM);
+    dl_ifft_buffer_.free();
+    dl_precoded_data_buffer_.free();
+    dl_modulated_buffer_.free();
 
 
-    free_buffer_2d(&(encode_stats_.task_count), TASK_BUFFER_FRAME_NUM);
+    encode_stats_.task_count.free();
     free_buffer_1d(&(encode_stats_.symbol_count));
-    free_buffer_2d(&(precode_stats_.task_count), TASK_BUFFER_FRAME_NUM);
+    precode_stats_.task_count.free();
     free_buffer_1d(&(precode_stats_.symbol_count));
-    free_buffer_2d(&(ifft_stats_.task_count), TASK_BUFFER_FRAME_NUM);
+    ifft_stats_.task_count.free();
     free_buffer_1d(&(ifft_stats_.symbol_count));
-    free_buffer_2d(&(tx_stats_.task_count), TASK_BUFFER_FRAME_NUM);
+    tx_stats_.task_count.free();
     free_buffer_1d(&(tx_stats_.symbol_count));
 }
 

--- a/src/millipede/millipede.hpp
+++ b/src/millipede/millipede.hpp
@@ -155,8 +155,8 @@ private:
      * packet_length = sizeof(int) * 4 + sizeof(ushort) * OFDM_FRAME_LEN * 2;
      * Second dimension of buffer_status: subframe_num_perframe * BS_ANT_NUM * SOCKET_BUFFER_FRAME_NUM
      */
-    char **socket_buffer_;
-    int **socket_buffer_status_;
+    Table<char> socket_buffer_;
+    Table<int> socket_buffer_status_;
     long long socket_buffer_size_;
     int socket_buffer_status_size_;
 
@@ -167,7 +167,7 @@ private:
      * First dimension: UE_NUM * TASK_BUFFER_FRAME_NUM
      * Second dimension: BS_ANT_NUM * OFDM_CA_NUM
      */
-    complex_float **csi_buffer_;
+    Table<complex_float> csi_buffer_;
 
     /** 
      * Data symbols after IFFT
@@ -175,40 +175,40 @@ private:
      * second dimension: BS_ANT_NUM * OFDM_CA_NUM
      * second dimension data order: SC1-32 of ants, SC33-64 of ants, ..., SC993-1024 of ants (32 blocks each with 32 subcarriers)
      */
-    complex_float **data_buffer_;
+    Table<complex_float> data_buffer_;
 
     /**
      * Calculated precoder
      * First dimension: OFDM_CA_NUM * TASK_BUFFER_FRAME_NUM
      * Second dimension: UE_NUM * BS_ANT_NUM
      */
-    complex_float **precoder_buffer_;
+    Table<complex_float> precoder_buffer_;
 
     /**
      * Data after equalization
      * First dimension: data_subframe_num_perframe (40-4) * TASK_BUFFER_FRAME_NUM
      * Second dimension: OFDM_CA_NUM * UE_NUM
      */
-    complex_float **equal_buffer_;
+    Table<complex_float> equal_buffer_;
 
     /**
      * Data after demodulation
      * First dimension: data_subframe_num_perframe (40-4) * TASK_BUFFER_FRAME_NUM
      * Second dimension: OFDM_CA_NUM * UE_NUM
      */
-    uint8_t **demod_hard_buffer_;
+    Table<uint8_t> demod_hard_buffer_;
 
-    int8_t **demod_soft_buffer_;
+    Table<int8_t> demod_soft_buffer_;
 
     /** 
      * Predicted CSI data 
      * First dimension: OFDM_CA_NUM 
      * Second dimension: BS_ANT_NUM * UE_NUM
      */
-    complex_float **pred_csi_buffer_;
+    Table<complex_float> pred_csi_buffer_;
 
 
-    uint8_t **decoded_buffer_;
+    Table<uint8_t> decoded_buffer_;
 
     RX_stats rx_stats_;
     FFT_stats fft_stats_;
@@ -220,7 +220,7 @@ private:
     Data_stats ifft_stats_;
     Data_stats tx_stats_;
 
-    int **delay_fft_queue;
+    Table<int> delay_fft_queue;
     int *delay_fft_queue_cnt;
 
     /* Downlink */   
@@ -229,8 +229,8 @@ private:
      * First dimension: data_subframe_num_perframe * UE_NUM
      * Second dimension: OFDM_CA_NUM
      */
-    int8_t **dl_IQ_data;
-    long long **dl_IQ_data_long;
+    Table<int8_t> *dl_IQ_data;
+    Table<long long> dl_IQ_data_long;
 
     /** 
      * Modulated data
@@ -245,14 +245,14 @@ private:
      * First dimension: data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM
      * second dimension: UE_NUM * OFDM_CA_NUM
      */
-    complex_float **dl_modulated_buffer_;
+    Table<complex_float> dl_modulated_buffer_;
 
     /**
      * Data for IFFT
      * First dimension: FFT_buffer_block_num = BS_ANT_NUM * data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM
      * Second dimension: OFDM_CA_NUM
      */
-    complex_float **dl_ifft_buffer_;
+    Table<complex_float> dl_ifft_buffer_;
 
     /**
      * Data after IFFT
@@ -262,18 +262,18 @@ private:
      */
     // DataBuffer dl_iffted_data_buffer_;
 
-    complex_float **dl_precoder_buffer_;
-    complex_float **recip_buffer_;
+    Table<complex_float> dl_precoder_buffer_;
+    Table<complex_float> recip_buffer_;
 
     /**
      * Precoded data
      * First dimension: total subframe number in the buffer: data_subframe_num_perframe * TASK_BUFFER_FRAME_NUM
      * second dimension: BS_ANT_NUM * OFDM_CA_NUM
      */
-    complex_float **dl_precoded_data_buffer_;
+    Table<complex_float> dl_precoded_data_buffer_;
 
 
-    int8_t **dl_encoded_buffer_;
+    Table<int8_t> dl_encoded_buffer_;
 
 
     /**

--- a/src/millipede/phy-ue.cpp
+++ b/src/millipede/phy-ue.cpp
@@ -74,8 +74,8 @@ Phy_UE::Phy_UE(Config *cfg)
     ////////////////////////////////////////
 
     // initialize rx buffer
-    alloc_buffer_2d(&rx_buffer_, rx_thread_num, rx_buffer_size, 64, 0);
-    alloc_buffer_2d(&rx_buffer_status_, rx_thread_num, rx_buffer_status_size, 64, 0);
+    rx_buffer_.malloc(rx_thread_num, rx_buffer_size, 64);
+    rx_buffer_status_.malloc_buffer_2d(rx_thread_num, rx_buffer_status_size, 64);
 
     // initialize FFT buffer
     size_t FFT_buffer_block_num = numAntennas * dl_symbol_perframe * TASK_BUFFER_FRAME_NUM;

--- a/src/millipede/stats.cpp
+++ b/src/millipede/stats.cpp
@@ -59,13 +59,13 @@ Stats::Stats(Config *cfg, int in_break_down_num,
     init_stats_worker_per_frame(&precode_stats_per_frame, break_down_num);
 
 #if DEBUG_UPDATE_STATS_DETAILED
-    alloc_buffer_2d(&csi_time_in_function_details, break_down_num-1, 10000, 4096, 1);
-    alloc_buffer_2d(&fft_time_in_function_details, break_down_num-1, 10000, 4096, 1);
-    alloc_buffer_2d(&zf_time_in_function_details, break_down_num-1, 10000, 4096, 1);
-    alloc_buffer_2d(&demul_time_in_function_details, break_down_num-1, 10000, 4096, 1);
+    csi_time_in_function_details.calloc(break_down_num-1, 10000, 4096);
+    fft_time_in_function_details.calloc(break_down_num-1, 10000, 4096);
+    zf_time_in_function_details.calloc(break_down_num-1, 10000, 4096);
+    demul_time_in_function_details.calloc(break_down_num-1, 10000, 4096);
 #endif
 
-    alloc_buffer_2d(&frame_start, cfg->socket_thread_num, 10240, 64, 1);
+    frame_start.calloc(cfg->socket_thread_num, 10240, 64);
 
 }
 
@@ -101,8 +101,8 @@ Stats::~Stats()
 
 void Stats::init_stats_worker(Stats_worker *stats_in_worker, int thread_num, int break_down_num)
 {
-    alloc_buffer_2d(&(stats_in_worker->task_duration), thread_num * 8, break_down_num, 32, 1);
-    alloc_buffer_1d(&(stats_in_worker->task_count), thread_num * 16, 32, 1);
+    stats_in_worker->task_duration.calloc(thread_num * 8, break_down_num, 32);
+    alloc_buffer_1d(&stats_in_worker->task_count, thread_num * 16, 32, 1);
 }
 
 void Stats::init_stats_worker_per_frame(Stats_worker_per_frame *stats_in_worker, int break_down_num)
@@ -114,8 +114,8 @@ void Stats::init_stats_worker_per_frame(Stats_worker_per_frame *stats_in_worker,
 
 void Stats::free_stats_worker(Stats_worker *stats_in_worker, int thread_num)
 {
-    free_buffer_2d(&(stats_in_worker->task_duration), thread_num * 8);
-    free_buffer_1d(&(stats_in_worker->task_count));
+    stats_in_worker->task_duration.free();
+    free_buffer_1d(&stats_in_worker->task_count);
 }
 
 void Stats::free_stats_worker_per_frame(Stats_worker_per_frame *stats_in_worker)

--- a/src/millipede/stats.hpp
+++ b/src/millipede/stats.hpp
@@ -18,7 +18,7 @@
 
 struct Stats_worker {
     /* accumulated task duration for all frames in each worker thread*/
-    double **task_duration;
+    Table<double> task_duration;
     /* accumulated task count for all frames in each worker thread*/
     int *task_count;
 };
@@ -132,7 +132,7 @@ public:
     Stats_worker encode_stats_worker;
     Stats_worker ifft_stats_worker;
     Stats_worker precode_stats_worker;
-    double **frame_start;
+    Table<double> frame_start;
  
 private:
     Config *config_;
@@ -175,10 +175,10 @@ private:
     double encode_time_in_function[10000] __attribute__( ( aligned (4096) ) ) ;
 
 #if DEBUG_UPDATE_STATS_DETAILED
-    double **csi_time_in_function_details;
-    double **fft_time_in_function_details;
-    double **zf_time_in_function_details;
-    double **demul_time_in_function_details;
+    Table<double> csi_time_in_function_details;
+    Table<double> fft_time_in_function_details;
+    Table<double> zf_time_in_function_details;
+    Table<double> demul_time_in_function_details;
 #endif
 
     Stats_worker csi_stats_worker_old;

--- a/src/millipede/txrx/txrx.cpp
+++ b/src/millipede/txrx/txrx.cpp
@@ -55,15 +55,16 @@ PacketTXRX::~PacketTXRX()
 }
 
 
-std::vector<pthread_t> PacketTXRX::startRecv(char** in_buffer, int** in_buffer_status, int in_buffer_frame_num, long long in_buffer_length, double **in_frame_start)
+std::vector<pthread_t> PacketTXRX::startRecv(Table<char> &in_buffer, Table<int> &in_buffer_status, int in_buffer_frame_num, long long in_buffer_length, Table<double> &in_frame_start)
 {
+    buffer_ = &in_buffer;
+    buffer_status_ = &in_buffer_status;
+    frame_start_ = &in_frame_start;
+
     // check length
     buffer_frame_num_ = in_buffer_frame_num;
     // assert(in_buffer_length == packet_length * buffer_frame_num_); // should be integer
     buffer_length_ = in_buffer_length;
-    buffer_ = in_buffer;  // for save data
-    buffer_status_ = in_buffer_status; // for save status
-    frame_start_ = in_frame_start;
 
 
     printf("create RX threads\n");
@@ -162,11 +163,11 @@ void *PacketTXRX::loopRecv(int tid)
     // moodycamel::ProducerToken *local_ptok = new moodycamel::ProducerToken(*message_queue_);
     moodycamel::ProducerToken *local_ptok = rx_ptoks_[tid];
 
-    char *buffer_ptr = buffer_[tid];
-    int *buffer_status_ptr = buffer_status_[tid];
+    char *buffer_ptr = (*buffer_)[tid];
+    int *buffer_status_ptr = (*buffer_status_)[tid];
     long long buffer_length = buffer_length_;
     int buffer_frame_num = buffer_frame_num_;
-    double *frame_start = frame_start_[tid];
+    double *frame_start = (*frame_start_)[tid];
 
     // walk through all the pages
 #if 0
@@ -379,11 +380,11 @@ void *PacketTXRX::loopTXRX(int tid)
 
 
     // RX  pointers
-    char* rx_buffer_ptr = buffer_[tid];
-    int* rx_buffer_status_ptr = buffer_status_[tid];
+    char* rx_buffer_ptr = (*buffer_)[tid];
+    int* rx_buffer_status_ptr = (*buffer_status_)[tid];
     long long rx_buffer_length = buffer_length_;
     int rx_buffer_frame_num = buffer_frame_num_;
-    double *rx_frame_start = frame_start_[tid];
+    double *rx_frame_start = (*frame_start_)[tid];
     char* rx_cur_buffer_ptr = rx_buffer_ptr;
     int* rx_cur_buffer_status_ptr = rx_buffer_status_ptr;
     int rx_offset = 0;

--- a/src/millipede/txrx/txrx.hpp
+++ b/src/millipede/txrx/txrx.hpp
@@ -117,7 +117,8 @@ public:
      * in_buffer_length: size of ring buffer
      * in_core_id: attach socket threads to {in_core_id, ..., in_core_id + RX_THREAD_NUM - 1}
     */ 
-    std::vector<pthread_t> startRecv(char** in_buffer, int** in_buffer_status, int in_buffer_frame_num, long long in_buffer_length, double **in_frame_start);
+  std::vector<pthread_t> startRecv(Table<char> &in_buffer, Table<int> &in_buffer_status, int in_buffer_frame_num, long long in_buffer_length,
+				   Table<double> &in_frame_start);
     std::vector<pthread_t> startTX(char* in_buffer, int* in_buffer_status, int in_buffer_frame_num, int in_buffer_length);
     /**
      * receive thread
@@ -166,8 +167,8 @@ private:
     int dst_port_start = 8000;
 #endif
 
-    char** buffer_;
-    int** buffer_status_;
+    Table<char> *buffer_;
+    Table<int> *buffer_status_;
     long long buffer_length_;
     int buffer_frame_num_;
 
@@ -180,7 +181,7 @@ private:
     int rx_thread_num_;
     int tx_thread_num_;
 
-    double **frame_start_;
+    Table<double> *frame_start_;
     // pointer of message_queue_
     moodycamel::ConcurrentQueue<Event_data> *message_queue_;
     moodycamel::ConcurrentQueue<Event_data> *task_queue_;


### PR DESCRIPTION
allocating an array of pointers, and then allocating memory
to set each pointer, allocate all the memory at once for
all the rows at once and compute the start of each row, rather
than looking it up in an auxiliary table.  This is accomplished
by the creation of a template Table<type> that remembers where
the memory begins and also the number of bytes allocated to
echo row.  The [] operator applied to a table compute the
beginning of the appropriate row and returns it.

Most of this change is changing class member and function parameter
declarations from the old type to the new, always by reference
and not by value, so that this is no implicit copying of tables.
Where a reference can't be used - as when setting an element of
a class after the class object has already been constructed -
a pointer replaces the preferred reference member.