### PR TITLE
Eliminate "*_Argos" versions of PackageTXRX functions.

### DIFF
--- a/src/millipede/txrx/txrx.cpp
+++ b/src/millipede/txrx/txrx.cpp
@@ -193,7 +193,7 @@ void* PacketTXRX::loopTXRX(int tid)
     return 0;
 }
 
-struct Packet* PacketTXRX::recv_enqueue(int tid, int comm_id, int rx_offset)
+struct Packet* PacketTXRX::recv_enqueue(int tid, int radio_id, int rx_offset)
 {
     moodycamel::ProducerToken* local_ptok = rx_ptoks_[tid];
     char* rx_buffer = (*buffer_)[tid];
@@ -207,7 +207,7 @@ struct Packet* PacketTXRX::recv_enqueue(int tid, int comm_id, int rx_offset)
         exit(0);
     }
     struct Packet* pkt = (struct Packet*)&rx_buffer[rx_offset * packet_length];
-    int recvlen = recv(socket_[tid], (char*)pkt, packet_length, 0);
+    int recvlen = recv(radio_id, (char*)pkt, packet_length, 0);
     if (recvlen < 0) {
         perror("recv failed");
         exit(0);
@@ -265,7 +265,7 @@ int PacketTXRX::dequeue_send(int tid)
     new (pkt) Packet(frame_id, symbol_id, 0 /* cell_id */, ant_id);
 
     // send data (one OFDM symbol)
-    if (sendto(socket_[tid], (char*)cur_buffer_ptr, packet_length, 0,
+    if (sendto(radio_id, (char*)cur_buffer_ptr, packet_length, 0,
             (struct sockaddr*)&servaddr_[tid], sizeof(servaddr_[tid]))
         < 0) {
         perror("socket sendto failed");

--- a/src/millipede/txrx/txrx.hpp
+++ b/src/millipede/txrx/txrx.hpp
@@ -125,7 +125,7 @@ public:
     typedef struct sockaddr_in6 sockaddr_t;
 #endif
     int dequeue_send(int tid);
-    struct Packet* recv_enqueue(int tid, int comm_id, int rx_offset);
+    struct Packet* recv_enqueue(int tid, int radio_id, int rx_offset);
 #ifdef USE_DPDK
     static void* loopRecv_DPDK(void* context);
 #endif

--- a/src/millipede/txrx/txrx_argos.cpp
+++ b/src/millipede/txrx/txrx_argos.cpp
@@ -154,7 +154,7 @@ void* PacketTXRX::loopTXRX(int tid)
     return 0;
 }
 
-struct Packet* PacketTXRX::recv_enqueue(int tid, int comm_id, int rx_offset)
+struct Packet* PacketTXRX::recv_enqueue(int tid, int radio_id, int rx_offset)
 {
     moodycamel::ProducerToken* local_ptok = rx_ptoks_[tid];
     char* rx_buffer = (*buffer_)[tid];
@@ -179,13 +179,13 @@ struct Packet* PacketTXRX::recv_enqueue(int tid, int comm_id, int rx_offset)
     // revamped
     long long frameTime;
     if (!config_->running
-        || radioconfig_->radioRx(comm_id, samp, frameTime) <= 0) {
+        || radioconfig_->radioRx(radio_id, samp, frameTime) <= 0) {
         return NULL;
     }
 
     int frame_id = (int)(frameTime >> 32);
     int symbol_id = (int)((frameTime >> 16) & 0xFFFF);
-    int ant_id = comm_id * nChannels;
+    int ant_id = radio_id * nChannels;
 
     for (int ch = 0; ch < nChannels; ++ch) {
         new (pkt[ch]) Packet(frame_id, symbol_id, 0 /* cell_id */, ant_id + ch);


### PR DESCRIPTION
Make arguments match between versions to make Argos names unnecessary.
Use the socket_ array and the serveraddr_ array in PacketTXRX for tcpip; don't
allocate them at all for Argos.