### PR TITLE
Changes for timing measurement

### DIFF
--- a/src/millipede/docoding.hpp
+++ b/src/millipede/docoding.hpp
@@ -48,8 +48,7 @@ private:
     Table<int8_t>& encoded_buffer_;
     struct bblib_ldpc_decoder_5gnr_response ldpc_decoder_5gnr_response {
     };
-    Table<double>& Encode_task_duration;
-    int* Encode_task_count;
+    DurationStat* duration_stat;
     const int16_t* pShiftMatrix;
     const int16_t* pMatrixNumPerCol;
     const int16_t* pAddr;
@@ -87,8 +86,7 @@ public:
 private:
     Table<int8_t>& llr_buffer_;
     Table<uint8_t>& decoded_buffer_;
-    Table<double>& Decode_task_duration;
-    int* Decode_task_count;
+    DurationStat* duration_stat;
     struct bblib_ldpc_decoder_5gnr_request ldpc_decoder_5gnr_request {
     };
     struct bblib_ldpc_decoder_5gnr_response ldpc_decoder_5gnr_response {

--- a/src/millipede/dodemul.hpp
+++ b/src/millipede/dodemul.hpp
@@ -70,9 +70,7 @@ private:
     Table<complex_float>& equal_buffer_;
     Table<uint8_t>& demod_hard_buffer_;
     Table<int8_t>& demod_soft_buffer_;
-
-    Table<double>& Demul_task_duration;
-    int* Demul_task_count;
+    DurationStat* duration_stat;
 
     /**
      * Intermediate buffer to gather raw data

--- a/src/millipede/doer.hpp
+++ b/src/millipede/doer.hpp
@@ -5,6 +5,7 @@ class Config;
 #include "buffer.hpp"
 #include "concurrent_queue_wrapper.hpp"
 #include "concurrentqueue.h"
+#include "stats.hpp"
 
 class Doer {
 public:

--- a/src/millipede/dofft.hpp
+++ b/src/millipede/dofft.hpp
@@ -74,12 +74,10 @@ private:
     Table<complex_float>& data_buffer_;
     Table<complex_float>& csi_buffer_;
     Table<complex_float>& calib_buffer_;
-    Table<double>* FFT_task_duration;
-    int* FFT_task_count;
-    Table<double>* CSI_task_duration;
-    int* CSI_task_count;
     DFTI_DESCRIPTOR_HANDLE mkl_handle;
     FFTBuffer fft_buffer_;
+    DurationStat* duration_stat_fft;
+    DurationStat* duration_stat_csi;
 };
 
 class DoIFFT : public Doer {
@@ -120,9 +118,7 @@ public:
 private:
     Table<complex_float>& dl_ifft_buffer_;
     char* dl_socket_buffer_;
-    ;
-    Table<double>* task_duration;
-    int* task_count;
+    DurationStat* duration_stat;
     DFTI_DESCRIPTOR_HANDLE mkl_handle;
 };
 

--- a/src/millipede/doprecode.hpp
+++ b/src/millipede/doprecode.hpp
@@ -85,10 +85,7 @@ private:
     Table<complex_float>& dl_ifft_buffer_;
     Table<int8_t>& dl_raw_data;
     Table<float> qam_table;
-
-    Table<double>& Precode_task_duration;
-    int* Precode_task_count;
-
+    DurationStat* duration_stat;
     complex_float* modulated_buffer_temp;
     complex_float* precoded_buffer_temp;
 };

--- a/src/millipede/dozf.cpp
+++ b/src/millipede/dozf.cpp
@@ -22,8 +22,7 @@ DoZF::DoZF(Config* in_config, int in_tid,
     , ul_precoder_buffer_(in_ul_precoder_buffer)
     , dl_precoder_buffer_(in_dl_precoder_buffer)
 {
-    ZF_task_duration = &in_stats_manager->zf_stats_worker.task_duration;
-    ZF_task_count = in_stats_manager->zf_stats_worker.task_count;
+    duration_stat = in_stats_manager->get_duration_stat(DoerType::kZF, in_tid);
     alloc_buffer_1d(&pred_csi_buffer, cfg->BS_ANT_NUM * cfg->UE_NUM, 64, 0);
     alloc_buffer_1d(&csi_gather_buffer, cfg->BS_ANT_NUM * cfg->UE_NUM, 64, 0);
 }
@@ -120,8 +119,7 @@ void DoZF::ZF_time_orthogonal(int offset)
         }
 
 #if DEBUG_UPDATE_STATS_DETAILED
-        double duration1 = get_time() - start_time1;
-        (*ZF_task_duration)[tid * 8][1] += duration1;
+        duration_stat->task_duration[1] += get_time() - start_time1;
 #endif
         cx_float* ptr_in = (cx_float*)csi_gather_buffer;
         cx_fmat mat_input(ptr_in, cfg->BS_ANT_NUM, cfg->UE_NUM, false);
@@ -132,14 +130,13 @@ void DoZF::ZF_time_orthogonal(int offset)
 
 #if DEBUG_UPDATE_STATS_DETAILED
         double start_time2 = get_time();
-        double duration2 = start_time2 - start_time1;
-        (*ZF_task_duration)[tid * 8][2] += duration2;
+        duration_stat->task_duration[2] += start_time2 - start_time1;
 #endif
 
         // cout<<"Precoder:" <<mat_output<<endl;
 #if DEBUG_UPDATE_STATS_DETAILED
         double duration3 = get_time() - start_time2;
-        (*ZF_task_duration)[tid * 8][3] += duration3;
+        duration_stat->task_duration[3] += duration3;
 #endif
         // // int mat_elem = UE_NUM * BS_ANT_NUM;
         // // int cache_line_num = mat_elem / 8;
@@ -151,9 +148,8 @@ void DoZF::ZF_time_orthogonal(int offset)
         // }
 
 #if DEBUG_UPDATE_STATS
-        ZF_task_count[tid * 16] = ZF_task_count[tid * 16] + 1;
-        double duration = get_time() - start_time1;
-        (*ZF_task_duration)[tid * 8][0] += duration;
+        duration_stat->task_count++;
+        duration_stat->task_duration[0] += get_time() - start_time1;
         // if (duration > 500) {
         //     printf("Thread %d ZF takes %.2f\n", tid, duration);
         // }
@@ -207,8 +203,7 @@ void DoZF::ZF_freq_orthogonal(int offset)
     }
 
 #if DEBUG_UPDATE_STATS_DETAILED
-    double duration1 = get_time() - start_time1;
-    (*ZF_task_duration)[tid * 8][1] += duration1;
+    duration_stat->task_duration[1] += get_time() - start_time1;
 #endif
     cx_float* ptr_in = (cx_float*)csi_gather_buffer;
     cx_fmat mat_input(ptr_in, cfg->BS_ANT_NUM, cfg->UE_NUM, false);
@@ -219,20 +214,17 @@ void DoZF::ZF_freq_orthogonal(int offset)
 
 #if DEBUG_UPDATE_STATS_DETAILED
     double start_time2 = get_time();
-    double duration2 = start_time2 - start_time1;
-    (*ZF_task_duration)[tid * 8][2] += duration2;
+    duration_stat->task_duration[2] += start_time2 - start_time1;
 #endif
 
     // cout<<"Precoder:" <<mat_output<<endl;
 #if DEBUG_UPDATE_STATS_DETAILED
-    double duration3 = get_time() - start_time2;
-    (*ZF_task_duration)[tid * 8][3] += duration3;
+    duration_stat->task_duration[3] += get_time() - start_time2;
 #endif
 
 #if DEBUG_UPDATE_STATS
-    ZF_task_count[tid * 16] = ZF_task_count[tid * 16] + 1;
-    double duration = get_time() - start_time1;
-    (*ZF_task_duration)[tid * 8][0] += duration;
+    duration_stat->task_count++;
+    duration_stat->task_duration[0] += get_time() - start_time1;
     // if (duration > 500) {
     //     printf("Thread %d ZF takes %.2f\n", tid, duration);
     // }

--- a/src/millipede/dozf.hpp
+++ b/src/millipede/dozf.hpp
@@ -86,9 +86,7 @@ private:
     Table<complex_float> recip_buffer_;
     Table<complex_float> ul_precoder_buffer_;
     Table<complex_float> dl_precoder_buffer_;
-
-    Table<double>* ZF_task_duration;
-    int* ZF_task_count;
+    DurationStat* duration_stat;
 
     /**
      * Intermediate buffer to gather CSI

--- a/src/millipede/reciprocity.hpp
+++ b/src/millipede/reciprocity.hpp
@@ -37,9 +37,7 @@ private:
 
     Table<complex_float> calib_buffer_;
     Table<complex_float> recip_buffer_;
-
-    Table<double>* RC_task_duration;
-    int* RC_task_count;
+    DurationStat* duration_stat;
 
     /**
      * Intermediate buffer to gather CSI

--- a/src/millipede/stats.cpp
+++ b/src/millipede/stats.cpp
@@ -19,29 +19,6 @@ Stats::Stats(Config* cfg, int break_down_num, int task_thread_num,
     rt_assert(break_down_num <= (int)kMaxStatBreakdown,
         "Statistics breakdown too high");
 
-    init_stats_worker(&csi_stats_worker, task_thread_num, break_down_num);
-    init_stats_worker(&fft_stats_worker, task_thread_num, break_down_num);
-    init_stats_worker(&zf_stats_worker, task_thread_num, break_down_num);
-    init_stats_worker(&demul_stats_worker, task_thread_num, break_down_num);
-    init_stats_worker(&decode_stats_worker, task_thread_num, break_down_num);
-    init_stats_worker(&encode_stats_worker, task_thread_num, break_down_num);
-    init_stats_worker(&ifft_stats_worker, task_thread_num, break_down_num);
-    init_stats_worker(&precode_stats_worker, task_thread_num, break_down_num);
-    init_stats_worker(&rc_stats_worker, task_thread_num, break_down_num);
-
-    init_stats_worker(&csi_stats_worker_old, task_thread_num, break_down_num);
-    init_stats_worker(&fft_stats_worker_old, task_thread_num, break_down_num);
-    init_stats_worker(&zf_stats_worker_old, task_thread_num, break_down_num);
-    init_stats_worker(&demul_stats_worker_old, task_thread_num, break_down_num);
-    init_stats_worker(
-        &decode_stats_worker_old, task_thread_num, break_down_num);
-    init_stats_worker(
-        &encode_stats_worker_old, task_thread_num, break_down_num);
-    init_stats_worker(&ifft_stats_worker_old, task_thread_num, break_down_num);
-    init_stats_worker(
-        &precode_stats_worker_old, task_thread_num, break_down_num);
-    init_stats_worker(&rc_stats_worker_old, task_thread_num, break_down_num);
-
 #if DEBUG_UPDATE_STATS_DETAILED
     csi_time_in_function_details.calloc(
         break_down_num - 1, kNumStatsFrames, 4096);
@@ -56,57 +33,20 @@ Stats::Stats(Config* cfg, int break_down_num, int task_thread_num,
     frame_start.calloc(config_->socket_thread_num, kNumStatsFrames, 64);
 }
 
-Stats::~Stats()
-{
-    free_stats_worker(&csi_stats_worker, task_thread_num);
-    free_stats_worker(&fft_stats_worker, task_thread_num);
-    free_stats_worker(&zf_stats_worker, task_thread_num);
-    free_stats_worker(&demul_stats_worker, task_thread_num);
-    free_stats_worker(&decode_stats_worker, task_thread_num);
-    free_stats_worker(&encode_stats_worker, task_thread_num);
-    free_stats_worker(&ifft_stats_worker, task_thread_num);
-    free_stats_worker(&precode_stats_worker, task_thread_num);
-    free_stats_worker(&rc_stats_worker, task_thread_num);
-
-    free_stats_worker(&csi_stats_worker_old, task_thread_num);
-    free_stats_worker(&fft_stats_worker_old, task_thread_num);
-    free_stats_worker(&zf_stats_worker_old, task_thread_num);
-    free_stats_worker(&demul_stats_worker_old, task_thread_num);
-    free_stats_worker(&decode_stats_worker_old, task_thread_num);
-    free_stats_worker(&encode_stats_worker_old, task_thread_num);
-    free_stats_worker(&ifft_stats_worker_old, task_thread_num);
-    free_stats_worker(&precode_stats_worker_old, task_thread_num);
-    free_stats_worker(&rc_stats_worker_old, task_thread_num);
-}
-
-void Stats::init_stats_worker(
-    Stats_worker* stats_in_worker, int thread_num, int break_down_num)
-{
-    stats_in_worker->task_duration.calloc(thread_num * 8, break_down_num, 32);
-    alloc_buffer_1d(&stats_in_worker->task_count, thread_num * 16, 32, 1);
-}
-
-void Stats::free_stats_worker(
-    Stats_worker* stats_in_worker, UNUSED int thread_num)
-{
-    stats_in_worker->task_duration.free();
-    free_buffer_1d(&stats_in_worker->task_count);
-}
+Stats::~Stats() {}
 
 void Stats::update_stats_for_breakdowns(Stats_worker_per_frame* stats_per_frame,
-    Stats_worker stats_in_worker, Stats_worker* stats_in_worker_old,
-    int thread_id, int break_down_num)
+    const DurationStat* duration_stat, DurationStat* duration_stat_old,
+    int break_down_num)
 {
     stats_per_frame->count_this_thread
-        = stats_in_worker.task_count[thread_id * 16]
-        - stats_in_worker_old->task_count[thread_id * 16];
+        = duration_stat->task_count - duration_stat_old->task_count;
     stats_per_frame->count_all_threads += stats_per_frame->count_this_thread;
-    stats_in_worker_old->task_count[thread_id * 16]
-        = stats_in_worker.task_count[thread_id * 16];
+
     for (int j = 0; j < break_down_num; j++) {
         stats_per_frame->duration_this_thread[j]
-            = stats_in_worker.task_duration[thread_id * 8][j]
-            - stats_in_worker_old->task_duration[thread_id * 8][j];
+            = duration_stat->task_duration[j]
+            - duration_stat_old->task_duration[j];
         stats_per_frame->duration_avg_threads[j]
             += stats_per_frame->duration_this_thread[j];
 #if DEBUG_PRINT_STATS_PER_THREAD
@@ -114,9 +54,8 @@ void Stats::update_stats_for_breakdowns(Stats_worker_per_frame* stats_per_frame,
             = stats_per_frame->duration_this_thread[j]
             / stats_per_frame->count_this_thread;
 #endif
-        stats_in_worker_old->task_duration[thread_id * 8][j]
-            = stats_in_worker.task_duration[thread_id * 8][j];
     }
+    *duration_stat_old = *duration_stat;
 }
 
 void Stats::compute_avg_over_threads(
@@ -277,10 +216,13 @@ void Stats::update_stats_in_dofft_bigstation(UNUSED int frame_id,
     Stats_worker_per_frame* csi_stats_per_frame)
 {
     for (int i = thread_num_offset; i < thread_num_offset + thread_num; i++) {
-        update_stats_for_breakdowns(fft_stats_per_frame, fft_stats_worker,
-            &fft_stats_worker_old, i, break_down_num);
-        update_stats_for_breakdowns(csi_stats_per_frame, csi_stats_worker,
-            &csi_stats_worker_old, i, break_down_num);
+        update_stats_for_breakdowns(fft_stats_per_frame,
+            get_duration_stat(DoerType::kFFT, i),
+            get_duration_stat_old(DoerType::kFFT, i), break_down_num);
+
+        update_stats_for_breakdowns(csi_stats_per_frame,
+            get_duration_stat(DoerType::kCSI, i),
+            get_duration_stat_old(DoerType::kCSI, i), break_down_num);
 
 #if DEBUG_PRINT_STATS_PER_THREAD
         double sum_time_this_frame_this_thread
@@ -302,8 +244,9 @@ void Stats::update_stats_in_dozf_bigstation(UNUSED int frame_id, int thread_num,
     int thread_num_offset, Stats_worker_per_frame* zf_stats_per_frame)
 {
     for (int i = thread_num_offset; i < thread_num_offset + thread_num; i++) {
-        update_stats_for_breakdowns(zf_stats_per_frame, zf_stats_worker,
-            &zf_stats_worker_old, i, break_down_num);
+        update_stats_for_breakdowns(zf_stats_per_frame,
+            get_duration_stat(DoerType::kZF, i),
+            get_duration_stat_old(DoerType::kZF, i), break_down_num);
 
 #if DEBUG_PRINT_STATS_PER_THREAD
         double sum_time_this_frame_this_thread
@@ -322,8 +265,9 @@ void Stats::update_stats_in_dodemul_bigstation(UNUSED int frame_id,
     Stats_worker_per_frame* demul_stats_per_frame)
 {
     for (int i = thread_num_offset; i < thread_num_offset + thread_num; i++) {
-        update_stats_for_breakdowns(demul_stats_per_frame, demul_stats_worker,
-            &demul_stats_worker_old, i, break_down_num);
+        update_stats_for_breakdowns(demul_stats_per_frame,
+            get_duration_stat(DoerType::kDemul, i),
+            get_duration_stat_old(DoerType::kDemul, i), break_down_num);
 
 #if DEBUG_PRINT_STATS_PER_THREAD
         double sum_time_this_frame_this_thread
@@ -343,10 +287,13 @@ void Stats::update_stats_in_doifft_bigstation(UNUSED int frame_id,
     Stats_worker_per_frame* csi_stats_per_frame)
 {
     for (int i = thread_num_offset; i < thread_num_offset + thread_num; i++) {
-        update_stats_for_breakdowns(ifft_stats_per_frame, ifft_stats_worker,
-            &ifft_stats_worker_old, i, break_down_num);
-        update_stats_for_breakdowns(csi_stats_per_frame, csi_stats_worker,
-            &csi_stats_worker_old, i, break_down_num);
+        update_stats_for_breakdowns(ifft_stats_per_frame,
+            get_duration_stat(DoerType::kIFFT, i),
+            get_duration_stat_old(DoerType::kIFFT, i), break_down_num);
+
+        update_stats_for_breakdowns(csi_stats_per_frame,
+            get_duration_stat(DoerType::kCSI, i),
+            get_duration_stat_old(DoerType::kCSI, i), break_down_num);
 
 #if DEBUG_PRINT_STATS_PER_THREAD
         double sum_time_this_frame_this_thread
@@ -370,7 +317,8 @@ void Stats::update_stats_in_doprecode_bigstation(UNUSED int frame_id,
 {
     for (int i = thread_num_offset; i < thread_num_offset + thread_num; i++) {
         update_stats_for_breakdowns(precode_stats_per_frame,
-            precode_stats_worker, &precode_stats_worker_old, i, break_down_num);
+            get_duration_stat(DoerType::kPrecode, i),
+            get_duration_stat_old(DoerType::kPrecode, i), break_down_num);
 
 #if DEBUG_PRINT_STATS_PER_THREAD
         double sum_time_this_frame_this_thread
@@ -423,16 +371,25 @@ void Stats::update_stats_in_functions_uplink_millipede(UNUSED int frame_id,
     Stats_worker_per_frame* decode_stats_per_frame)
 {
     for (int i = 0; i < task_thread_num; i++) {
-        update_stats_for_breakdowns(fft_stats_per_frame, fft_stats_worker,
-            &fft_stats_worker_old, i, break_down_num);
-        update_stats_for_breakdowns(csi_stats_per_frame, csi_stats_worker,
-            &csi_stats_worker_old, i, break_down_num);
-        update_stats_for_breakdowns(zf_stats_per_frame, zf_stats_worker,
-            &zf_stats_worker_old, i, break_down_num);
-        update_stats_for_breakdowns(demul_stats_per_frame, demul_stats_worker,
-            &demul_stats_worker_old, i, break_down_num);
-        update_stats_for_breakdowns(decode_stats_per_frame, decode_stats_worker,
-            &decode_stats_worker_old, i, break_down_num);
+        update_stats_for_breakdowns(fft_stats_per_frame,
+            get_duration_stat(DoerType::kFFT, i),
+            get_duration_stat_old(DoerType::kFFT, i), break_down_num);
+
+        update_stats_for_breakdowns(csi_stats_per_frame,
+            get_duration_stat(DoerType::kCSI, i),
+            get_duration_stat_old(DoerType::kCSI, i), break_down_num);
+
+        update_stats_for_breakdowns(zf_stats_per_frame,
+            get_duration_stat(DoerType::kZF, i),
+            get_duration_stat_old(DoerType::kZF, i), break_down_num);
+
+        update_stats_for_breakdowns(demul_stats_per_frame,
+            get_duration_stat(DoerType::kDemul, i),
+            get_duration_stat_old(DoerType::kDemul, i), break_down_num);
+
+        update_stats_for_breakdowns(decode_stats_per_frame,
+            get_duration_stat(DoerType::kDecode, i),
+            get_duration_stat_old(DoerType::kDecode, i), break_down_num);
 
 #if DEBUG_PRINT_STATS_PER_THREAD
         double sum_time_this_frame_this_thread
@@ -478,16 +435,25 @@ void Stats::update_stats_in_functions_downlink_millipede(UNUSED int frame_id,
 {
 
     for (int i = 0; i < task_thread_num; i++) {
-        update_stats_for_breakdowns(ifft_stats_per_frame, ifft_stats_worker,
-            &ifft_stats_worker_old, i, break_down_num);
-        update_stats_for_breakdowns(csi_stats_per_frame, csi_stats_worker,
-            &csi_stats_worker_old, i, break_down_num);
-        update_stats_for_breakdowns(zf_stats_per_frame, zf_stats_worker,
-            &zf_stats_worker_old, i, break_down_num);
+        update_stats_for_breakdowns(ifft_stats_per_frame,
+            get_duration_stat(DoerType::kIFFT, i),
+            get_duration_stat_old(DoerType::kIFFT, i), break_down_num);
+
+        update_stats_for_breakdowns(csi_stats_per_frame,
+            get_duration_stat(DoerType::kCSI, i),
+            get_duration_stat_old(DoerType::kCSI, i), break_down_num);
+
+        update_stats_for_breakdowns(zf_stats_per_frame,
+            get_duration_stat(DoerType::kZF, i),
+            get_duration_stat_old(DoerType::kZF, i), break_down_num);
+
         update_stats_for_breakdowns(precode_stats_per_frame,
-            precode_stats_worker, &precode_stats_worker_old, i, break_down_num);
-        update_stats_for_breakdowns(encode_stats_per_frame, encode_stats_worker,
-            &encode_stats_worker_old, i, break_down_num);
+            get_duration_stat(DoerType::kPrecode, i),
+            get_duration_stat_old(DoerType::kPrecode, i), break_down_num);
+
+        update_stats_for_breakdowns(encode_stats_per_frame,
+            get_duration_stat(DoerType::kEncode, i),
+            get_duration_stat_old(DoerType::kEncode, i), break_down_num);
 
 #if DEBUG_PRINT_STATS_PER_THREAD
         double sum_time_this_frame_this_thread
@@ -609,20 +575,13 @@ void Stats::save_to_file()
     fclose(fp_debug);
 }
 
-int Stats::compute_total_count(Stats_worker stats_in_worker, int thread_num)
+int Stats::get_total_task_count(DoerType doer_type, int thread_num)
 {
     int total_count = 0;
-    for (int i = 0; i < thread_num; i++)
-        total_count = total_count + stats_in_worker.task_count[i * 16];
+    for (int i = 0; i < thread_num; i++) {
+        total_count = total_count + get_duration_stat(doer_type, i)->task_count;
+    }
     return total_count;
-}
-
-double Stats::compute_count_percentage(
-    Stats_worker stats_in_worker, int total_count, int thread_id)
-{
-    double percentage = 100
-        * ((double)stats_in_worker.task_count[thread_id * 16] / total_count);
-    return percentage;
 }
 
 void Stats::print_summary()
@@ -633,110 +592,106 @@ void Stats::print_summary()
     int OFDM_DATA_NUM = config_->OFDM_DATA_NUM;
     int ul_data_subframe_num_perframe = config_->ul_data_symbol_num_perframe;
     int dl_data_subframe_num_perframe = config_->dl_data_symbol_num_perframe;
-    int CSI_total_count
-        = compute_total_count(csi_stats_worker, task_thread_num);
-    int FFT_total_count
-        = compute_total_count(fft_stats_worker, task_thread_num);
-    int ZF_total_count = compute_total_count(zf_stats_worker, task_thread_num);
-    int Demul_total_count
-        = compute_total_count(demul_stats_worker, task_thread_num);
+    int csi_total_count = get_total_task_count(DoerType::kCSI, task_thread_num);
+    int fft_total_count = get_total_task_count(DoerType::kFFT, task_thread_num);
+    int zf_total_count = get_total_task_count(DoerType::kZF, task_thread_num);
+    int demul_total_count
+        = get_total_task_count(DoerType::kDemul, task_thread_num);
 #if USE_LDPC
     int UE_NUM = config_->UE_NUM;
-    int Decode_total_count
-        = compute_total_count(decode_stats_worker, task_thread_num);
-    int Encode_total_count
-        = compute_total_count(encode_stats_worker, task_thread_num);
+    int decode_total_count
+        = get_total_task_count(DoerType::kDecode, task_thread_num);
+    int encode_total_count
+        = get_total_task_count(DoerType::kEncode, task_thread_num);
     int nblocksInSymbol = config_->LDPC_config.nblocksInSymbol;
 #endif
-    int IFFT_total_count
-        = compute_total_count(ifft_stats_worker, task_thread_num);
-    int Precode_total_count
-        = compute_total_count(precode_stats_worker, task_thread_num);
-    double csi_frames = (double)CSI_total_count / BS_ANT_NUM / PILOT_NUM;
-    double zf_frames = (double)ZF_total_count / config_->zf_block_num;
+    int ifft_total_count
+        = get_total_task_count(DoerType::kIFFT, task_thread_num);
+    int precode_total_count
+        = get_total_task_count(DoerType::kPrecode, task_thread_num);
+    double csi_frames = (double)csi_total_count / BS_ANT_NUM / PILOT_NUM;
+    double zf_frames = (double)zf_total_count / config_->zf_block_num;
+
     if (config_->downlink_mode) {
-        double precode_frames = (double)Precode_total_count / OFDM_DATA_NUM
+        double precode_frames = (double)precode_total_count / OFDM_DATA_NUM
             / dl_data_subframe_num_perframe;
-        double ifft_frames = (double)IFFT_total_count / BS_ANT_NUM
+        double ifft_frames = (double)ifft_total_count / BS_ANT_NUM
             / dl_data_subframe_num_perframe;
         printf("Downlink totals: ");
-        printf("CSI %d (%.2f frames), ", CSI_total_count, csi_frames);
-        printf("ZF: %d (%.2f frames), ", ZF_total_count, zf_frames);
+        printf("CSI %d (%.2f frames), ", csi_total_count, csi_frames);
+        printf("ZF: %d (%.2f frames), ", zf_total_count, zf_frames);
 #if USE_LDPC
-        double encode_frames = (double)Encode_total_count / nblocksInSymbol
+        double encode_frames = (double)encode_total_count / nblocksInSymbol
             / UE_NUM / dl_data_subframe_num_perframe;
-        printf("Encode: %d (%.2f frames), ", Encode_total_count, encode_frames);
+        printf("Encode: %d (%.2f frames), ", encode_total_count, encode_frames);
 #endif
         printf(
-            "Precode: %d (%.2f frames), ", Precode_total_count, precode_frames);
-        printf("IFFT: %d (%.2f frames)", IFFT_total_count, ifft_frames);
+            "Precode: %d (%.2f frames), ", precode_total_count, precode_frames);
+        printf("IFFT: %d (%.2f frames)", ifft_total_count, ifft_frames);
         printf("\n");
         for (int i = 0; i < task_thread_num; i++) {
-            double percent_CSI = compute_count_percentage(
-                csi_stats_worker, CSI_total_count, i);
-            double percent_ZF
-                = compute_count_percentage(zf_stats_worker, ZF_total_count, i);
-            double percent_Precode = compute_count_percentage(
-                precode_stats_worker, Precode_total_count, i);
-            double percent_IFFT = compute_count_percentage(
-                ifft_stats_worker, IFFT_total_count, i);
+            int num_csi_i = get_duration_stat(DoerType::kCSI, i)->task_count;
+            int num_zf_i = get_duration_stat(DoerType::kZF, i)->task_count;
+            int num_precode_i
+                = get_duration_stat(DoerType::kPrecode, i)->task_count;
+            int num_ifft_i = get_duration_stat(DoerType::kIFFT, i)->task_count;
+
+            double percent_csi = num_csi_i * 100.0 / csi_total_count;
+            double percent_zf = num_zf_i * 100.0 / zf_total_count;
+            double percent_precode
+                = num_precode_i * 100.0 / precode_total_count;
+            double percent_ifft = num_ifft_i * 100.0 / ifft_total_count;
             printf("thread %d performed ", i);
-            printf("CSI: %d (%.2f%%), ", csi_stats_worker.task_count[i * 16],
-                percent_CSI);
-            printf("ZF: %d (%.2f%%), ", zf_stats_worker.task_count[i * 16],
-                percent_ZF);
+            printf("CSI: %d (%.2f%%), ", num_csi_i, percent_csi);
+            printf("ZF: %d (%.2f%%), ", num_zf_i, percent_zf);
 #if USE_LDPC
-            double percent_Encode = compute_count_percentage(
-                encode_stats_worker, Encode_total_count, i);
-            printf("Encode: %d (%.2f%%), ",
-                encode_stats_worker.task_count[i * 16], percent_Encode);
+            int num_encode_i
+                = get_duration_stat(DoerType::kEncode, i)->task_count;
+            double percent_encode = num_encode_i * 100.0 / encode_total_count;
+            printf("Encode: %d (%.2f%%), ", num_encode_i, percent_encode);
 #endif
-            printf("Precode: %d (%.2f%%), ",
-                precode_stats_worker.task_count[i * 16], percent_Precode);
-            printf("IFFT: %d (%.2f%%)", ifft_stats_worker.task_count[i * 16],
-                percent_IFFT);
+            printf("Precode: %d (%.2f%%), ", num_precode_i, percent_precode);
+            printf("IFFT: %d (%.2f%%)", num_ifft_i, percent_ifft);
             printf("\n");
         }
     } else {
-        double fft_frames = (double)FFT_total_count / BS_ANT_NUM
+        double fft_frames = (double)fft_total_count / BS_ANT_NUM
             / ul_data_subframe_num_perframe;
-        double demul_frames = (double)Demul_total_count / OFDM_DATA_NUM
+        double demul_frames = (double)demul_total_count / OFDM_DATA_NUM
             / ul_data_subframe_num_perframe;
         printf("Uplink totals: ");
-        printf("CSI %d (%.2f frames), ", CSI_total_count, csi_frames);
-        printf("ZF: %d (%.2f frames), ", ZF_total_count, zf_frames);
-        printf("FFT: %d (%.2f frames), ", FFT_total_count, fft_frames);
-        printf("Demul: %d (%.2f frames) ", Demul_total_count, demul_frames);
+        printf("CSI %d (%.2f frames), ", csi_total_count, csi_frames);
+        printf("ZF: %d (%.2f frames), ", zf_total_count, zf_frames);
+        printf("FFT: %d (%.2f frames), ", fft_total_count, fft_frames);
+        printf("Demul: %d (%.2f frames) ", demul_total_count, demul_frames);
 #if USE_LDPC
-        double decode_frames = (double)Decode_total_count / nblocksInSymbol
+        double decode_frames = (double)decode_total_count / nblocksInSymbol
             / UE_NUM / ul_data_subframe_num_perframe;
-        printf("Decode: %d (%.2f frames)", Decode_total_count, decode_frames);
+        printf("Decode: %d (%.2f frames)", decode_total_count, decode_frames);
 #endif
         printf("\n");
         for (int i = 0; i < task_thread_num; i++) {
-            double percent_CSI = compute_count_percentage(
-                csi_stats_worker, CSI_total_count, i);
-            double percent_FFT = compute_count_percentage(
-                fft_stats_worker, FFT_total_count, i);
-            double percent_ZF
-                = compute_count_percentage(zf_stats_worker, ZF_total_count, i);
-            double percent_Demul = compute_count_percentage(
-                demul_stats_worker, Demul_total_count, i);
+            int num_csi_i = get_duration_stat(DoerType::kCSI, i)->task_count;
+            int num_fft_i = get_duration_stat(DoerType::kIFFT, i)->task_count;
+            int num_zf_i = get_duration_stat(DoerType::kZF, i)->task_count;
+            int num_demul_i
+                = get_duration_stat(DoerType::kDemul, i)->task_count;
+
+            double percent_csi = num_csi_i * 100.0 / csi_total_count;
+            double percent_fft = num_fft_i * 100.0 / fft_total_count;
+            double percent_zf = num_zf_i * 100.0 / zf_total_count;
+            double percent_demul = num_demul_i * 100.0 / demul_total_count;
 
             printf("Thread %d performed: ", i);
-            printf("CSI: %d (%.1f%%), ", csi_stats_worker.task_count[i * 16],
-                percent_CSI);
-            printf("ZF: %d (%.1f%%), ", zf_stats_worker.task_count[i * 16],
-                percent_ZF);
-            printf("FFT: %d (%.1f%%), ", fft_stats_worker.task_count[i * 16],
-                percent_FFT);
-            printf("Demul: %d (%.1f%%) ", demul_stats_worker.task_count[i * 16],
-                percent_Demul);
+            printf("CSI: %d (%.1f%%), ", num_csi_i, percent_csi);
+            printf("ZF: %d (%.1f%%), ", num_zf_i, percent_zf);
+            printf("FFT: %d (%.1f%%), ", num_fft_i, percent_fft);
+            printf("Demul: %d (%.1f%%) ", num_demul_i, percent_demul);
 #if USE_LDPC
-            double percent_Decode = compute_count_percentage(
-                decode_stats_worker, Decode_total_count, i);
-            printf("Decode: %d (%.1f%%) ",
-                decode_stats_worker.task_count[i * 16], percent_Decode);
+            int num_decode_i
+                = get_duration_stat(DoerType::kDecode, i)->task_count;
+            double percent_decode = num_decode_i * 100.0 / decode_total_count;
+            printf("Decode: %d (%.1f%%) ", num_decode_i, percent_decode);
 #endif
             printf("\n");
         }

--- a/src/millipede/stats.hpp
+++ b/src/millipede/stats.hpp
@@ -17,11 +17,11 @@
 
 static constexpr size_t kMaxStatBreakdown = 4;
 
-struct Stats_worker {
-    /* accumulated task duration for all frames in each worker thread*/
-    Table<double> task_duration; // (thread_num * 8) x break_down_num
-    /* accumulated task count for all frames in each worker thread*/
-    int* task_count; // thead_num  * 16
+/* Accumulated task duration for all frames in each worker thread */
+struct DurationStat {
+    double task_duration[kMaxStatBreakdown];
+    size_t task_count;
+    DurationStat() { memset(this, 0, sizeof(DurationStat)); }
 };
 
 struct Stats_worker_per_frame {
@@ -30,7 +30,6 @@ struct Stats_worker_per_frame {
     int count_this_thread = 0;
     double duration_avg_threads[kMaxStatBreakdown];
     int count_all_threads = 0;
-
     Stats_worker_per_frame()
     {
         memset(this, 0, sizeof(Stats_worker_per_frame));
@@ -58,18 +57,30 @@ enum class TsType : size_t {
 static constexpr size_t kNumTimestampTypes
     = static_cast<size_t>(TsType::kTXDone) + 1;
 
+// Types of Millipede Doers
+enum class DoerType : size_t {
+    kFFT,
+    kCSI,
+    kZF,
+    kDemul,
+    kDecode,
+    kEncode,
+    kIFFT,
+    kPrecode,
+    kRC
+};
+static constexpr size_t kNumDoerTypes = static_cast<size_t>(DoerType::kRC) + 1;
+
 class Stats {
 public:
     Stats(Config* cfg, int break_down_num, int task_thread_num,
         int fft_thread_num, int zf_thread_num, int demul_thread_num);
     ~Stats();
 
-    void init_stats_worker(
-        Stats_worker* stats_in_worker, int thread_num, int break_down_num);
-    void free_stats_worker(Stats_worker* stats_in_worker, int thread_num);
     void update_stats_for_breakdowns(Stats_worker_per_frame* stats_per_frame,
-        Stats_worker stats_in_worker, Stats_worker* stats_in_worker_old,
-        int thread_id, int break_down_num);
+        const DurationStat* duration_stat, DurationStat* stats_in_worker_old,
+        int break_down_num);
+
     void compute_avg_over_threads(Stats_worker_per_frame* stats_per_frame,
         int thread_num, int break_down_num);
     void print_per_thread_per_task(Stats_worker_per_frame stats_per_frame);
@@ -79,9 +90,7 @@ public:
     void update_stats_in_functions_downlink(int frame_id);
     void save_to_file();
 
-    int compute_total_count(Stats_worker stats_in_worker, int thread_num);
-    double compute_count_percentage(
-        Stats_worker stats_in_worker, int total_count, int thread_id);
+    int get_total_task_count(DoerType doer_type, int thread_num);
     void print_summary();
 
     size_t last_frame_id;
@@ -108,16 +117,23 @@ public:
                                [frame_id % kNumStatsFrames];
     }
 
-    /* accumulated task duration for all frames in each worker thread*/
-    Stats_worker csi_stats_worker;
-    Stats_worker fft_stats_worker;
-    Stats_worker zf_stats_worker;
-    Stats_worker demul_stats_worker;
-    Stats_worker decode_stats_worker;
-    Stats_worker encode_stats_worker;
-    Stats_worker ifft_stats_worker;
-    Stats_worker precode_stats_worker;
-    Stats_worker rc_stats_worker;
+    /// Get the DurationStat object used by thread thread_id for DoerType
+    /// doer_type
+    DurationStat* get_duration_stat(DoerType doer_type, size_t thread_id)
+    {
+        return &worker_durations[thread_id]
+                    .duration_stat[static_cast<size_t>(doer_type)];
+    }
+
+    /// The master thread uses a stale copy of DurationStats to compute
+    /// differences. This gets the DurationStat object for thread thread_id
+    /// for DoerType doer_type.
+    DurationStat* get_duration_stat_old(DoerType doer_type, size_t thread_id)
+    {
+        return &worker_durations_old[thread_id]
+                    .duration_stat[static_cast<size_t>(doer_type)];
+    }
+
     Table<double> frame_start;
 
 private:
@@ -175,6 +191,14 @@ private:
     /// processing
     double master_timestamps[kNumTimestampTypes][kNumStatsFrames];
 
+    /// Running time duration statistics. Each worker thread has one
+    /// DurationStat object for every Doer type. The master thread keeps stale
+    /// ("old") copies of all DurationStat objects.
+    struct {
+        DurationStat duration_stat[kNumDoerTypes];
+        uint8_t false_sharing_padding[64];
+    } worker_durations[kMaxThreads], worker_durations_old[kMaxThreads];
+
     double csi_time_in_function[kNumStatsFrames];
     double fft_time_in_function[kNumStatsFrames];
     double zf_time_in_function[kNumStatsFrames];
@@ -191,16 +215,6 @@ private:
     Table<double> zf_time_in_function_details;
     Table<double> demul_time_in_function_details;
 #endif
-
-    Stats_worker csi_stats_worker_old;
-    Stats_worker fft_stats_worker_old;
-    Stats_worker zf_stats_worker_old;
-    Stats_worker demul_stats_worker_old;
-    Stats_worker decode_stats_worker_old;
-    Stats_worker encode_stats_worker_old;
-    Stats_worker ifft_stats_worker_old;
-    Stats_worker precode_stats_worker_old;
-    Stats_worker rc_stats_worker_old;
 };
 
 #endif


### PR DESCRIPTION
* Renames `Stats_worker` to `DurationStats`
* Use 2D arrays `worker_durations` and `worker_durations_old` to hold timing measurements from workers. These arrays are indexed by thread ID and the Doer's type.
* `Stats_worker` (now `DurationStats`) is now statically-sized
* All `Stats_worker_per_frame` objects are now non-global, clarifying their lifetime