### PR TITLE
Move barriers for radio_lib to radio_lib.cpp

### DIFF
--- a/src/millipede/radio_lib.hpp
+++ b/src/millipede/radio_lib.hpp
@@ -36,7 +36,6 @@ public:
 private:
     struct RadioConfigContext {
         RadioConfig* brs;
-        std::atomic_int* threadCount;
         size_t tid;
     };
     static void* initBSRadio_launch(void* in_context);


### PR DESCRIPTION
Also avoid `new` and `delete` for contexts.