### PR TITLE
Fix usage and resolution of paths to be normal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ CTestTestfile.cmake
 /sim
 /millipede
 /data_generator
+
+# IDE config files #
+# ##################
+.vscode

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ Millipede is a high-performance system for massive-MIMO baseband processing.
    * Instead of `cmake ..` above, run `cmake -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc -DUSE_LDPC=1 ..`.
 
  * Run Millipede with simulated client traffic
-   * First, run `./data_generator data/tddconfig-sim-ul.json` to generate data
+   * First, return to the base directory (`cd ..`), then run `./build/data_generator data/tddconfig-sim-ul.json` to generate data
      files.
-   * In one terminal, run `./millipede data/tddconfig-sim-ul.json` to start
+   * In one terminal, run `./build/millipede data/tddconfig-sim-ul.json` to start
      Millipede with uplink configuration.
-   * In another terminal, run  `./sender --num_threads=2 --core_offset=0
+   * In another terminal, run  `./build/sender --num_threads=2 --core_offset=0
      --delay=5000 --enable_slow_start=false
      --conf_file=data/tddconfig-sim-ul.json` to start the simulated traffic
      sender with uplink configuration.

--- a/data/data_generator/data_generator.cpp
+++ b/data/data_generator/data_generator.cpp
@@ -39,16 +39,13 @@ float rand_float_from_short(float min, float max)
 
 int main(int argc, char* argv[])
 {
-    std::string confFile;
-    if (argc == 2)
-        confFile = std::string("/") + std::string(argv[1]);
-    else
-        confFile = "/data/tddconfig-sim-ul.json";
     std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
-    std::string filename = cur_directory + confFile;
+    std::string confFile = cur_directory + "/data/tddconfig-sim-ul.json";
+    if (argc == 2)
+        confFile = std::string(argv[1]);
 
-    printf("Config file: %s\n", filename.c_str());
-    auto* config_ = new Config(filename.c_str());
+    printf("Config file: %s\n", confFile.c_str());
+    auto* config_ = new Config(confFile.c_str());
 
     printf("LDPC %s\n", kUseLDPC ? "enabled" : "disabled");
     printf("Using %s-orthogonal pilots\n",
@@ -159,12 +156,12 @@ int main(int argc, char* argv[])
                 = mod_single_uint8((uint8_t)mod_input[n][i], mod_table);
     }
 
-    printf("Saving raw data\n");
 
     if (kUseLDPC) {
         std::string filename_input = cur_directory + "/data/LDPC_orig_data_"
             + std::to_string(OFDM_CA_NUM) + "_ant" + std::to_string(UE_NUM)
             + ".bin";
+        printf("Saving raw data (using LDPC) to %s\n", filename_input.c_str());
         FILE* fp_input = fopen(filename_input.c_str(), "wb");
         for (size_t i = 0; i < numberCodeblocks; i++) {
             uint8_t* ptr = (uint8_t*)input[i];
@@ -177,6 +174,7 @@ int main(int argc, char* argv[])
         std::string filename_input = cur_directory + "/data/orig_data_"
             + std::to_string(OFDM_CA_NUM) + "_ant" + std::to_string(UE_NUM)
             + ".bin";
+        printf("Saving raw data to %s\n", filename_input.c_str());
         FILE* fp_input = fopen(filename_input.c_str(), "wb");
         for (size_t i = 0; i < numberCodeblocks; i++) {
             uint8_t* ptr = (uint8_t*)mod_input[i];
@@ -306,11 +304,11 @@ int main(int argc, char* argv[])
         }
     }
 
-    printf("saving rx data...\n");
     std::string filename_rx = cur_directory
         + (kUseLDPC ? "/data/LDPC_rx_data_" : "/data/rx_data_")
         + std::to_string(OFDM_CA_NUM) + "_ant" + std::to_string(BS_ANT_NUM)
         + ".bin";
+    printf("Saving rx data to %s\n", filename_rx.c_str());
     FILE* fp_rx = fopen(filename_rx.c_str(), "wb");
     for (int i = 0; i < symbol_num_perframe; i++) {
         float* ptr = (float*)rx_data_all_symbols[i];
@@ -443,12 +441,11 @@ int main(int argc, char* argv[])
         }
     }
 
-    printf("saving dl tx data...\n");
     std::string filename_dl_tx = cur_directory
         + (kUseLDPC ? "/data/LDPC_dl_tx_data_" : "/data/dl_tx_data_")
         + std::to_string(OFDM_CA_NUM) + "_ant" + std::to_string(BS_ANT_NUM)
         + ".bin";
-
+    printf("Saving dl tx data to %s\n", filename_dl_tx.c_str());
     FILE* fp_dl_tx = fopen(filename_dl_tx.c_str(), "wb");
     for (int i = 0; i < dl_data_symbol_num_perframe; i++) {
         short* ptr = (short*)dl_tx_data[i];

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -7,15 +7,16 @@
 
 int main(int argc, char const* argv[])
 {
+    std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
     std::string confFile;
     int thread_num, core_offset, delay;
     if (argc == 5) {
         thread_num = strtol(argv[1], NULL, 10);
         core_offset = strtol(argv[2], NULL, 10);
         delay = strtol(argv[3], NULL, 10);
-        confFile = std::string("/") + std::string(argv[4]);
+        confFile = std::string(argv[4]);
     } else {
-        confFile = "/data/tddconfig-sim-dl.json";
+        confFile = cur_directory + "/data/tddconfig-sim-dl.json";
         thread_num = 4;
         core_offset = 22;
         delay = 5000;
@@ -24,9 +25,7 @@ int main(int argc, char const* argv[])
                "core offset, 3. frame duration, 4. config file)\n");
         printf("Arguments set to default: 4, 22, 5000, %s\n", confFile.c_str());
     }
-    std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
-    std::string filename = cur_directory + confFile;
-    auto* cfg = new Config(filename.c_str());
+    auto* cfg = new Config(confFile.c_str());
     cfg->genData();
     Simulator* simulator;
     int ret;

--- a/simulator/sender.cpp
+++ b/simulator/sender.cpp
@@ -420,9 +420,9 @@ void Sender::create_threads(void* (*worker)(void*), int tid_start, int tid_end)
 
 void Sender::write_stats_to_file(size_t tx_frame_count) const
 {
-    printf("Printing sender results to file...\n");
     std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
     std::string filename = cur_directory + "/data/tx_result.txt";
+    printf("Printing sender results to file \"%s\"...\n", filename.c_str());
     FILE* fp_debug = fopen(filename.c_str(), "w");
     rt_assert(fp_debug != nullptr, "Failed to open stats file");
     for (size_t i = 0; i < tx_frame_count; i++) {

--- a/simulator/sender_cli.cpp
+++ b/simulator/sender_cli.cpp
@@ -9,14 +9,14 @@
 DEFINE_uint64(num_threads, 4, "Number of sender threads");
 DEFINE_uint64(core_offset, 0, "Core ID of the first sender thread");
 DEFINE_uint64(delay, 5000, "Frame duration in microseconds");
-DEFINE_string(conf_file, "/data/tddconfig-sim-dl.json", "Config filename");
+DEFINE_string(conf_file, TOSTRING(PROJECT_DIRECTORY) "/data/tddconfig-sim-dl.json", "Config filename");
 DEFINE_bool(enable_slow_start, true, "Send frames slowly at first.");
 
 int main(int argc, char* argv[])
 {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
-    std::string filename = cur_directory + "/" + FLAGS_conf_file;
+    std::string filename = FLAGS_conf_file;
     auto* cfg = new Config(filename.c_str());
     cfg->genData();
 

--- a/src/mac/mac_client_main.cpp
+++ b/src/mac/mac_client_main.cpp
@@ -7,14 +7,15 @@
 
 int main(int argc, char* argv[])
 {
+    std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
     std::string confFile;
     int core_offset, delay;
     if (argc == 4) {
         core_offset = strtol(argv[1], NULL, 10);
         delay = strtol(argv[2], NULL, 10);
-        confFile = std::string("/") + std::string(argv[3]);
+        confFile = std::string(argv[3]);
     } else {
-        confFile = "/data/tddconfig-sim-dl.json";
+        confFile = cur_directory + "/data/tddconfig-sim-dl.json";
         core_offset = 22;
         delay = 5000;
         printf("Wrong arguments (requires 3 arguments: 1. number of tx "
@@ -22,9 +23,7 @@ int main(int argc, char* argv[])
         printf("Arguments set to default: 22, 5000, %s\n", confFile.c_str());
     }
 
-    std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
-    std::string filename = cur_directory + confFile;
-    auto* cfg = new Config(filename.c_str());
+    auto* cfg = new Config(confFile.c_str());
     cfg->genData();
     auto* sender = new SimpleClientMac(cfg, core_offset, delay);
 

--- a/src/millipede/main.cpp
+++ b/src/millipede/main.cpp
@@ -8,14 +8,11 @@
 
 int main(int argc, char* argv[])
 {
-    std::string confFile;
-    if (argc == 2)
-        confFile = std::string("/") + std::string(argv[1]);
-    else
-        confFile = "/data/tddconfig-sim-ul.json";
     std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
-    std::string filename = cur_directory + confFile;
-    auto* cfg = new Config(filename.c_str());
+    std::string confFile = cur_directory + "/data/tddconfig-sim-ul.json";
+    if (argc == 2)
+        confFile = std::string(argv[1]);
+    auto* cfg = new Config(confFile.c_str());
     cfg->genData();
     Millipede* millipede_cli;
 

--- a/src/millipede/txrx/txrx.hpp
+++ b/src/millipede/txrx/txrx.hpp
@@ -51,7 +51,6 @@ typedef unsigned short ushort;
  * with real wireless hardware peers (antenna hubs for the server, UE devices
  * for the client).
  */
-
 class PacketTXRX {
 public:
     PacketTXRX(Config* cfg, size_t in_core_offset = 1);

--- a/test/test_millipede/.gitignore
+++ b/test/test_millipede/.gitignore
@@ -1,0 +1,6 @@
+# Executables #
+###############
+/sender
+/sim
+/millipede
+/data_generator

--- a/test/test_millipede/main.cpp
+++ b/test/test_millipede/main.cpp
@@ -178,14 +178,12 @@ void check_correctness_dl(Config* cfg)
 
 int main(int argc, char* argv[])
 {
-    std::string confFile;
-    if (argc == 2)
-        confFile = std::string("/") + std::string(argv[1]);
-    else
-        confFile = "/data/tddconfig-correctness-test-ul.json";
     std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
-    std::string filename = cur_directory + confFile;
-    auto* cfg = new Config(filename.c_str());
+    std::string confFile = cur_directory + "/data/tddconfig-correctness-test-ul.json";
+    if (argc == 2)
+        confFile = std::string(argv[1]);
+
+    auto* cfg = new Config(confFile.c_str());
     cfg->genData();
     Millipede* millipede_cli;
 

--- a/test/test_millipede/test_millipede.sh
+++ b/test/test_millipede/test_millipede.sh
@@ -48,28 +48,28 @@ for i in `seq 1 $num_iters`; do
     echo "==========================================="
     echo "Generating data for uplink correctness test $i......"
     echo -e "===========================================\n"
-    ./data_generator data/tddconfig-correctness-test-ul.json
+    ./data_generator ../../data/tddconfig-correctness-test-ul.json
     
     echo -e "-------------------------------------------------------\n\n\n"
     echo "======================================"
     echo "Running uplink correctness test $i......"
     echo -e "======================================\n"
     # We sleep before starting the sender to allow the Millipede server to start
-    ./millipede data/tddconfig-correctness-test-ul.json &
-    sleep 1; ./sender --num_threads 4 --core_offset 10 --delay 5000 --conf_file "data/tddconfig-correctness-test-ul.json"
+    ./millipede ../../data/tddconfig-correctness-test-ul.json &
+    sleep 1; ./sender --num_threads 4 --core_offset 10 --delay 5000 --conf_file "../../data/tddconfig-correctness-test-ul.json"
     wait
 
     echo "==========================================="
     echo "Generating data for downlink correctness test $i......"
     echo -e "===========================================\n"
-    ./data_generator data/tddconfig-correctness-test-dl.json
+    ./data_generator ../../data/tddconfig-correctness-test-dl.json
 
     echo -e "-------------------------------------------------------\n\n\n"
     echo "======================================"
     echo "Running downlink correctness test $i......"
     echo -e "======================================\n"
-    ./millipede data/tddconfig-correctness-test-dl.json &
-    sleep 1; ./sender --num_threads 4 --core_offset 10 --delay 5000 --conf_file "data/tddconfig-correctness-test-dl.json"
+    ./millipede ../../data/tddconfig-correctness-test-dl.json &
+    sleep 1; ./sender --num_threads 4 --core_offset 10 --delay 5000 --conf_file "../../data/tddconfig-correctness-test-dl.json"
     echo -e "-------------------------------------------------------\n\n\n"
     wait
   } >> $out_file


### PR DESCRIPTION
Previously, paths were specified from a fixed base directory, which made it confusing and difficult to precisely specify an input file in both scripts and executables on the command line. 

This PR fixes that issue by adopting normal path usage, which allows shell autocomplete to work properly. It also makes it explicitly clear which files from which directories are being used, e.g., as default paths when a command-line arg is missing. 

I'm not sure if it's 100% complete, as I don't have experience with running various combinations of other executables & scripts. If I missed something, let me know and I'll add it too. 