### PR TITLE
Partial set of minor changes from work on distributed Millipede

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -39,6 +39,7 @@ home_dir = expanduser("~")
 flags = [
     '-x',
     'c++',
+    '-DMLPD_LOG_LEVEL=MLPD_LOG_LEVEL_TRACE',
     '-DUSE_DPDK=on',
     '-I'+ '/opt/FlexRAN-FEC-SDK-19-04/sdk/source/phy/lib_ldpc_decoder_5gnr',
     '-I'+ '/opt/FlexRAN-FEC-SDK-19-04/sdk/source/phy/lib_ldpc_encoder_5gnr',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,3 +330,9 @@ add_executable(test_udp_client_server
   test/unit_tests/test_udp_client_server.cc)
 target_link_libraries(test_udp_client_server ${COMMON_LIBS})
 add_test(NAME test_udp_client_server COMMAND test_udp_client_server)
+
+add_executable(test_concurrent_queue
+  test/unit_tests/test_concurrent_queue.cc
+   $<TARGET_OBJECTS:common_sources_lib>)
+target_link_libraries(test_concurrent_queue ${COMMON_LIBS})
+add_test(NAME test_concurrent_queue COMMAND test_concurrent_queue)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -133,6 +133,45 @@ static inline void rt_assert(bool condition, std::string throw_str, char* s)
     }
 }
 
+/// Returns the greatest common divisor of `a` and `b`.
+inline size_t gcd(size_t a, size_t b)
+{
+    if (a == 0)
+        return b;
+    return gcd(b % a, a);
+}
+
+/// Returns the least common multiple of `a` and `b`.
+inline size_t lcm(size_t a, size_t b) { return (a * b) / gcd(a, b); }
+
+/// A range type with an inclusive start bound and an exclusive end bound.
+struct Range {
+    const size_t start;
+    const size_t end;
+
+    /// Create a new Range with the given `start` and `end` values.
+    /// `end` must be greater than or equal to `start`.
+    Range(size_t start, size_t end)
+        : start(start)
+        , end(end)
+    {
+        rt_assert(end >= start, "Invalid range, end must be >= start");
+    }
+
+    /// Returns `true` if this range contains the given `value`.
+    bool contains(size_t value) const
+    {
+        return (value >= start) && (value < end);
+    }
+
+    std::string to_string() const
+    {
+        std::ostringstream ret;
+        ret << "[" << start << ":" << end << ")";
+        return ret.str();
+    }
+};
+
 class SlowRand {
     std::random_device rand_dev; // Non-pseudorandom seed for twister
     std::mt19937_64 mt;

--- a/src/millipede/docoding.hpp
+++ b/src/millipede/docoding.hpp
@@ -14,8 +14,8 @@
 #include "gettime.h"
 #include "memory_manage.h"
 #include "modulation.hpp"
-#include "stats.hpp"
 #include "phy_stats.hpp"
+#include "stats.hpp"
 #include <armadillo>
 #include <iostream>
 #include <stdio.h>

--- a/src/millipede/doer.hpp
+++ b/src/millipede/doer.hpp
@@ -33,8 +33,26 @@ public:
         return false;
     }
 
+    /// The main event handling function that performs Doer-specific work.
+    /// Doers that handle only one event type use this signature.
+    virtual Event_data launch(size_t tag)
+    {
+        _unused(tag);
+        rt_assert(false, "Doer: launch(tag) not implemented");
+        return Event_data();
+    }
+
+    /// The main event handling function that performs Doer-specific work.
+    /// Doers that handle multiple event types use this signature.
+    virtual Event_data launch(size_t tag, EventType event_type)
+    {
+        _unused(tag);
+        _unused(event_type);
+        rt_assert(false, "Doer: launch(tag, event_type) not implemented");
+        return Event_data();
+    }
+
 protected:
-    virtual Event_data launch(size_t tag) = 0;
     Doer(Config* in_config, int in_tid, double freq_ghz,
         moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
         moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
@@ -47,6 +65,8 @@ protected:
         , worker_producer_token(worker_producer_token)
     {
     }
+
+    virtual ~Doer() = default;
 
     Config* cfg;
     int tid; // Thread ID of this Doer

--- a/test/unit_tests/test_concurrent_queue.cc
+++ b/test/unit_tests/test_concurrent_queue.cc
@@ -1,0 +1,143 @@
+#include "concurrentqueue.h"
+#include <gtest/gtest.h>
+#include <thread>
+
+static constexpr size_t kNumWorkers = 14;
+static constexpr size_t kMaxTestNum = (1 << 24);
+
+struct item_t {
+    size_t value;
+    size_t padding[7];
+
+    item_t(){};
+    item_t(size_t value)
+        : value(value)
+    {
+    }
+};
+static_assert(sizeof(item_t) == 64, "");
+
+// Test if the master can enqueue to specific workers
+void MasterToWorkerStatic_master(moodycamel::ConcurrentQueue<item_t>* queue,
+    moodycamel::ProducerToken** ptoks)
+{
+    for (size_t i = 0; i < kMaxTestNum; i++) {
+        queue->enqueue(*ptoks[i % kNumWorkers], item_t(i));
+    }
+}
+
+void MasterToWorkerStatic_worker(size_t worker_id,
+    moodycamel::ConcurrentQueue<item_t>* queue, moodycamel::ProducerToken* ptok)
+{
+    size_t next_expected = worker_id;
+    while (next_expected < kMaxTestNum) {
+        item_t item;
+        if (queue->try_dequeue_from_producer(*ptok, item)) {
+            ASSERT_EQ(item.value, next_expected);
+            next_expected += kNumWorkers;
+        }
+    }
+}
+
+TEST(TestConcurrentQueue, MasterToWorkerStatic)
+{
+    moodycamel::ConcurrentQueue<item_t> queue;
+    moodycamel::ProducerToken* ptoks[kNumWorkers];
+    for (size_t i = 0; i < kNumWorkers; i++) {
+        ptoks[i] = new moodycamel::ProducerToken(queue);
+    }
+
+    auto master = std::thread(MasterToWorkerStatic_master, &queue, ptoks);
+    std::thread workers[kNumWorkers];
+    for (size_t i = 0; i < kNumWorkers; i++) {
+        workers[i]
+            = std::thread(MasterToWorkerStatic_worker, i, &queue, ptoks[i]);
+    }
+    master.join();
+    for (auto& w : workers)
+        w.join();
+
+    for (size_t i = 0; i < kNumWorkers; i++) {
+        delete ptoks[i];
+    }
+}
+
+// Test if the token affects the performance when master dequeues items from workers
+void WorkerToMaster_master(moodycamel::ConcurrentQueue<item_t>* queue)
+{
+    item_t item;
+    size_t sum = 0;
+    while (sum < kMaxTestNum) {
+        if (queue->try_dequeue(item)) {
+            sum++;
+        }
+    }
+}
+
+void WorkerToMaster_worker_with_token(size_t worker_id,
+    moodycamel::ConcurrentQueue<item_t>* queue, moodycamel::ProducerToken* ptok)
+{
+    size_t next_expected = worker_id;
+    while (next_expected < kMaxTestNum) {
+        item_t item(next_expected);
+        if (queue->enqueue(*ptok, item)) {
+            next_expected += kNumWorkers;
+        }
+    }
+}
+
+void WorkerToMaster_worker_without_token(
+    size_t worker_id, moodycamel::ConcurrentQueue<item_t>* queue)
+{
+    size_t next_expected = worker_id;
+    while (next_expected < kMaxTestNum) {
+        item_t item(next_expected);
+        if (queue->enqueue(item)) {
+            next_expected += kNumWorkers;
+        }
+    }
+}
+
+TEST(TestConcurrentQueue, WorkerToMasterWithTokens)
+{
+    moodycamel::ConcurrentQueue<item_t> queue;
+    moodycamel::ProducerToken* ptoks[kNumWorkers];
+    for (size_t i = 0; i < kNumWorkers; i++) {
+        ptoks[i] = new moodycamel::ProducerToken(queue);
+    }
+
+    auto master = std::thread(WorkerToMaster_master, &queue);
+    std::thread workers[kNumWorkers];
+    for (size_t i = 0; i < kNumWorkers; i++) {
+        workers[i] = std::thread(
+            WorkerToMaster_worker_with_token, i, &queue, ptoks[i]);
+    }
+    master.join();
+    for (auto& w : workers)
+        w.join();
+
+    for (size_t i = 0; i < kNumWorkers; i++) {
+        delete ptoks[i];
+    }
+}
+
+TEST(TestConcurrentQueue, WorkerToMasterWithoutTokens)
+{
+    moodycamel::ConcurrentQueue<item_t> queue;
+
+    auto master = std::thread(WorkerToMaster_master, &queue);
+    std::thread workers[kNumWorkers];
+    for (size_t i = 0; i < kNumWorkers; i++) {
+        workers[i]
+            = std::thread(WorkerToMaster_worker_without_token, i, &queue);
+    }
+    master.join();
+    for (auto& w : workers)
+        w.join();
+}
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The goal here is to reduce the diff of our main working branch (`merge_subcarrier_doer_single_queue`) from develop.

Some of the additions in this PR are unused (e.g., `struct Range` and the `launch()` function with two arguments) for now.