### PR TITLE
fix bad EVM when scrambler off

### DIFF
--- a/src/agora/doencode.cc
+++ b/src/agora/doencode.cc
@@ -117,7 +117,9 @@ EventData DoEncode::Launch(size_t tag) {
     scrambler_->Scramble(scrambler_buffer_, ldpc_input, num_bytes_per_cb);
     ldpc_input = scrambler_buffer_;
   }
-  std::memset(&ldpc_input[num_bytes_per_cb], 0u, num_padding_bytes_per_cb);
+  if (num_padding_bytes_per_cb > 0) {
+    std::memset(&ldpc_input[num_bytes_per_cb], 0u, num_padding_bytes_per_cb);
+  }
 
   if (kDebugTxData) {
     std::stringstream dataprint;

--- a/src/agora/doencode.cc
+++ b/src/agora/doencode.cc
@@ -111,13 +111,13 @@ EventData DoEncode::Launch(size_t tag) {
 
   int8_t* ldpc_input = tx_data_ptr;
   const size_t num_bytes_per_cb = cfg_->NumBytesPerCb(dir_);
+  const size_t num_padding_bytes_per_cb = cfg_->NumPaddingBytesPerCb(dir_);
 
   if (this->cfg_->ScrambleEnabled()) {
     scrambler_->Scramble(scrambler_buffer_, ldpc_input, num_bytes_per_cb);
     ldpc_input = scrambler_buffer_;
   }
-  std::memset(&ldpc_input[num_bytes_per_cb], 0u,
-              cfg_->NumPaddingBytesPerCb(Direction::kUplink));
+  std::memset(&ldpc_input[num_bytes_per_cb], 0u, num_padding_bytes_per_cb);
 
   if (kDebugTxData) {
     std::stringstream dataprint;

--- a/src/agora/radio/radio_data_plane_soapy.cc
+++ b/src/agora/radio/radio_data_plane_soapy.cc
@@ -33,7 +33,7 @@ inline void RadioDataPlaneSoapy::Close() { return RadioDataPlane::Close(); }
 inline void RadioDataPlaneSoapy::Setup() {
   SoapySDR::Kwargs sargs;
   //Helps with the disable stream, errors (-2)
-  //sargs["SYNC_ACTIVATE"] = "false";
+  sargs["SYNC_ACTIVATE"] = "false";
   return RadioDataPlane::Setup(sargs);
 }
 

--- a/src/agora/radio/radio_data_plane_socket.cc
+++ b/src/agora/radio/radio_data_plane_socket.cc
@@ -93,7 +93,7 @@ void RadioDataPlaneSocket::Setup() {
     rxstream_args["iris:ip6_dst"] = socket_.Address();
     rxstream_args["iris:udp_dst"] = socket_.Port();
     //Helps with the disable strea, errors (-2)
-    //rxstream_args["SYNC_ACTIVATE"] = "false";
+    rxstream_args["SYNC_ACTIVATE"] = "false";
 
     AGORA_LOG_FRAME(
         "Setting stream destination - iris:ip6_dst %s\n iris:udp_dst %s\n",

--- a/src/agora/radio/radio_soapysdr.cc
+++ b/src/agora/radio/radio_soapysdr.cc
@@ -123,7 +123,6 @@ void RadioSoapySdr::Init(const Config* cfg, size_t id,
       // remote::type = faros for hub controlled radios
       args["remote:mtu"] = "1500";
       args["remote:ipver"] = "6";
-      sargs["SYNC_ACTIVATE"] = "false";
     } else {
       args["driver"] = "uhd";
       args["addr"] = SerialNumber();

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1157,7 +1157,6 @@ void Config::GenData() {
       ul_num_bytes_per_cb_ + ul_num_padding_bytes_per_cb_, std::byte(0));
 
   int8_t* ldpc_input = nullptr;
-
   // Encode uplink bits
   Table<int8_t> ul_encoded_bits;
   ul_encoded_bits.Malloc(this->frame_.NumULSyms() * ul_num_blocks_per_symbol,
@@ -1187,9 +1186,10 @@ void Config::GenData() {
           ldpc_input = GetInfoBits(ul_bits_, Direction::kUplink, i, j, k);
         }
         //Clean padding
-        std::memset(&ldpc_input[ul_num_bytes_per_cb_], 0u,
-                    ul_num_padding_bytes_per_cb_);
-
+        if (ul_num_bytes_per_cb_ > 0) {
+          std::memset(&ldpc_input[ul_num_bytes_per_cb_], 0u,
+                      ul_num_padding_bytes_per_cb_);
+        }
         LdpcEncodeHelper(ul_ldpc_config_.BaseGraph(),
                          ul_ldpc_config_.ExpansionFactor(),
                          ul_ldpc_config_.NumRows(), coded_bits_ptr,
@@ -1301,8 +1301,10 @@ void Config::GenData() {
         } else {
           ldpc_input = GetInfoBits(dl_bits_, Direction::kDownlink, i, j, k);
         }
-        std::memset(&ldpc_input[dl_num_bytes_per_cb_], 0u,
-                    dl_num_padding_bytes_per_cb_);
+        if (dl_num_padding_bytes_per_cb_ > 0) {
+          std::memset(&ldpc_input[dl_num_bytes_per_cb_], 0u,
+                      dl_num_padding_bytes_per_cb_);
+        }
 
         LdpcEncodeHelper(dl_ldpc_config_.BaseGraph(),
                          dl_ldpc_config_.ExpansionFactor(),

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1182,7 +1182,7 @@ void Config::GenData() {
               ul_scramble_buffer.data(),
               GetInfoBits(ul_bits_, Direction::kUplink, i, j, k),
               ul_num_bytes_per_cb_);
-          ldpc_input = ul_scramble_buffer.data();
+          ldpc_input = reinterpret_cast<int8_t*>(ul_scramble_buffer.data());
         } else {
           ldpc_input = GetInfoBits(ul_bits_, Direction::kUplink, i, j, k);
         }
@@ -1297,7 +1297,7 @@ void Config::GenData() {
               dl_scramble_buffer.data(),
               GetInfoBits(dl_bits_, Direction::kDownlink, i, j, k),
               dl_num_bytes_per_cb_);
-          ldpc_input = dl_scramble_buffer.data();
+          ldpc_input = reinterpret_cast<int8_t*>(dl_scramble_buffer.data());
         } else {
           ldpc_input = GetInfoBits(dl_bits_, Direction::kDownlink, i, j, k);
         }
@@ -1452,7 +1452,6 @@ void Config::GenData() {
   dl_encoded_bits.Free();
   ul_encoded_bits.Free();
   FreeBuffer1d(&pilot_ifft);
-  delete[] dl_scramble_buffer;
 }
 
 Config::~Config() {

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -615,6 +615,8 @@ Config::Config(std::string jsonfilename)
   }
 
   ul_num_bytes_per_cb_ = ul_ldpc_config_.NumCbLen() / 8;
+  ul_num_padding_bytes_per_cb_ =
+      Roundup<64>(ul_num_bytes_per_cb_) - ul_num_bytes_per_cb_;
   ul_data_bytes_num_persymbol_ =
       ul_num_bytes_per_cb_ * ul_ldpc_config_.NumBlocksInSymbol();
   ul_mac_packet_length_ = ul_data_bytes_num_persymbol_;
@@ -628,6 +630,8 @@ Config::Config(std::string jsonfilename)
   ul_mac_bytes_num_perframe_ = ul_mac_packet_length_ * ul_mac_packets_perframe_;
 
   dl_num_bytes_per_cb_ = dl_ldpc_config_.NumCbLen() / 8;
+  dl_num_padding_bytes_per_cb_ =
+      Roundup<64>(dl_num_bytes_per_cb_) - dl_num_bytes_per_cb_;
   dl_data_bytes_num_persymbol_ =
       dl_num_bytes_per_cb_ * dl_ldpc_config_.NumBlocksInSymbol();
   dl_mac_packet_length_ = dl_data_bytes_num_persymbol_;
@@ -1027,7 +1031,7 @@ void Config::GenData() {
   const size_t dl_num_bytes_per_ue_pad =
       Roundup<64>(this->dl_num_bytes_per_cb_) *
       this->dl_ldpc_config_.NumBlocksInSymbol();
-  dl_bits_.Malloc(this->frame_.NumDLSyms(),
+  dl_bits_.Calloc(this->frame_.NumDLSyms(),
                   dl_num_bytes_per_ue_pad * this->ue_ant_num_,
                   Agora_memory::Alignment_t::kAlign64);
   dl_iq_f_.Calloc(this->frame_.NumDLSyms(), ofdm_data_num_ * ue_ant_num_,
@@ -1039,7 +1043,7 @@ void Config::GenData() {
   const size_t ul_num_bytes_per_ue_pad =
       Roundup<64>(this->ul_num_bytes_per_cb_) *
       this->ul_ldpc_config_.NumBlocksInSymbol();
-  ul_bits_.Malloc(this->frame_.NumULSyms(),
+  ul_bits_.Calloc(this->frame_.NumULSyms(),
                   ul_num_bytes_per_ue_pad * this->ue_ant_num_,
                   Agora_memory::Alignment_t::kAlign64);
   ul_iq_f_.Calloc(this->frame_.NumULSyms(),
@@ -1149,9 +1153,8 @@ void Config::GenData() {
       this->ul_ldpc_config_.NumBlocksInSymbol() * this->ue_ant_num_;
 
   // Used as an input ptr to
-  auto* ul_scramble_buffer =
-      new int8_t[ul_num_bytes_per_cb_ +
-                 kLdpcHelperFunctionInputBufferSizePaddingBytes]();
+  auto* ul_scramble_buffer = new int8_t[Roundup<64>(ul_num_bytes_per_cb_)]();
+  int8_t* ldpc_input = nullptr;
 
   // Encode uplink bits
   Table<int8_t> ul_encoded_bits;
@@ -1172,14 +1175,17 @@ void Config::GenData() {
             ul_encoded_bits[i * ul_num_blocks_per_symbol +
                             j * ul_ldpc_config_.NumBlocksInSymbol() + k];
 
-        std::memcpy(ul_scramble_buffer,
-                    GetInfoBits(ul_bits_, Direction::kUplink, i, j, k),
-                    ul_num_bytes_per_cb_);
         if (scramble_enabled_) {
+          std::memcpy(ul_scramble_buffer,
+                      GetInfoBits(ul_bits_, Direction::kUplink, i, j, k),
+                      ul_num_bytes_per_cb_);
           scrambler->Scramble(ul_scramble_buffer, ul_num_bytes_per_cb_);
+          ldpc_input = ul_scramble_buffer;
+        } else {
+          ldpc_input = GetInfoBits(ul_bits_, Direction::kUplink, i, j, k);
         }
-        std::memset(&ul_scramble_buffer[ul_num_bytes_per_cb_], 0u,
-                    kLdpcHelperFunctionInputBufferSizePaddingBytes);
+        std::memset(&ldpc_input[ul_num_bytes_per_cb_], 0u,
+                    ul_num_padding_bytes_per_cb_);
 
         LdpcEncodeHelper(ul_ldpc_config_.BaseGraph(),
                          ul_ldpc_config_.ExpansionFactor(),
@@ -1262,9 +1268,7 @@ void Config::GenData() {
   const size_t dl_num_blocks_per_symbol =
       this->dl_ldpc_config_.NumBlocksInSymbol() * this->ue_ant_num_;
 
-  auto* dl_scramble_buffer =
-      new int8_t[dl_num_bytes_per_cb_ +
-                 kLdpcHelperFunctionInputBufferSizePaddingBytes]();
+  auto* dl_scramble_buffer = new int8_t[Roundup<64>(dl_num_bytes_per_cb_)]();
 
   Table<int8_t> dl_encoded_bits;
   dl_encoded_bits.Malloc(this->frame_.NumDLSyms() * dl_num_blocks_per_symbol,
@@ -1284,14 +1288,17 @@ void Config::GenData() {
             dl_encoded_bits[i * dl_num_blocks_per_symbol +
                             j * dl_ldpc_config_.NumBlocksInSymbol() + k];
 
-        std::memcpy(dl_scramble_buffer,
-                    GetInfoBits(dl_bits_, Direction::kDownlink, i, j, k),
-                    dl_num_bytes_per_cb_);
         if (scramble_enabled_) {
+          std::memcpy(dl_scramble_buffer,
+                      GetInfoBits(dl_bits_, Direction::kDownlink, i, j, k),
+                      dl_num_bytes_per_cb_);
           scrambler->Scramble(dl_scramble_buffer, dl_num_bytes_per_cb_);
+          ldpc_input = dl_scramble_buffer;
+        } else {
+          ldpc_input = GetInfoBits(dl_bits_, Direction::kDownlink, i, j, k);
         }
-        std::memset(&dl_scramble_buffer[dl_num_bytes_per_cb_], 0u,
-                    kLdpcHelperFunctionInputBufferSizePaddingBytes);
+        std::memset(&ldpc_input[dl_num_bytes_per_cb_], 0u,
+                    dl_num_padding_bytes_per_cb_);
 
         LdpcEncodeHelper(dl_ldpc_config_.BaseGraph(),
                          dl_ldpc_config_.ExpansionFactor(),

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -252,6 +252,10 @@ class Config {
     return dir == Direction::kUplink ? this->ul_num_bytes_per_cb_
                                      : this->dl_num_bytes_per_cb_;
   }
+  inline size_t NumPaddingBytesPerCb(Direction dir) const {
+    return dir == Direction::kUplink ? this->ul_num_padding_bytes_per_cb_
+                                     : this->dl_num_padding_bytes_per_cb_;
+  }
   inline size_t MacDataBytesNumPerframe(Direction dir) const {
     return dir == Direction::kUplink ? this->ul_mac_data_bytes_num_perframe_
                                      : this->dl_mac_data_bytes_num_perframe_;
@@ -884,6 +888,10 @@ class Config {
   // Number of bytes per code block
   size_t ul_num_bytes_per_cb_;
   size_t dl_num_bytes_per_cb_;
+
+  // Number of padding bytes per code block
+  size_t ul_num_padding_bytes_per_cb_;
+  size_t dl_num_padding_bytes_per_cb_;
 
   bool fft_in_rru_;  // If true, the RRU does FFT instead of Agora
   const std::string config_filename_;

--- a/src/common/utils_ldpc.h
+++ b/src/common/utils_ldpc.h
@@ -12,6 +12,7 @@
 // Since the LDPC helper function input parameter undergoes 32byte read/write it
 // is necessary to pad the input buffers 32 bytes max (ie 32 will work for all
 // configurations)
+constexpr size_t kLdpcHelperFunctionInputBufferSizePaddingBytes = 32;
 
 LDPC_ADAPTER_P LdpcSelectAdapterFunc(uint16_t zcSize, uint8_t num_ways);
 

--- a/src/common/utils_ldpc.h
+++ b/src/common/utils_ldpc.h
@@ -12,7 +12,6 @@
 // Since the LDPC helper function input parameter undergoes 32byte read/write it
 // is necessary to pad the input buffers 32 bytes max (ie 32 will work for all
 // configurations)
-constexpr size_t kLdpcHelperFunctionInputBufferSizePaddingBytes = 32;
 
 LDPC_ADAPTER_P LdpcSelectAdapterFunc(uint16_t zcSize, uint8_t num_ways);
 

--- a/src/common/utils_ldpc.h
+++ b/src/common/utils_ldpc.h
@@ -12,7 +12,7 @@
 // Since the LDPC helper function input parameter undergoes 32byte read/write it
 // is necessary to pad the input buffers 32 bytes max (ie 32 will work for all
 // configurations)
-constexpr size_t kLdpcHelperFunctionInputBufferSizePaddingBytes = 32;
+//constexpr size_t kLdpcHelperFunctionInputBufferSizePaddingBytes = 32;
 
 LDPC_ADAPTER_P LdpcSelectAdapterFunc(uint16_t zcSize, uint8_t num_ways);
 

--- a/src/common/utils_ldpc.h
+++ b/src/common/utils_ldpc.h
@@ -12,7 +12,6 @@
 // Since the LDPC helper function input parameter undergoes 32byte read/write it
 // is necessary to pad the input buffers 32 bytes max (ie 32 will work for all
 // configurations)
-//constexpr size_t kLdpcHelperFunctionInputBufferSizePaddingBytes = 32;
 
 LDPC_ADAPTER_P LdpcSelectAdapterFunc(uint16_t zcSize, uint8_t num_ways);
 

--- a/src/data_generator/data_generator.cc
+++ b/src/data_generator/data_generator.cc
@@ -163,7 +163,8 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
         scrambler->Scramble(ul_scrambler_buffer.data(), ul_cb_bytes);
       }
       std::memset(&ul_scrambler_buffer.at(ul_cb_bytes), 0u, ul_cb_padding);
-      this->GenCodeblock(Direction::kUplink, ul_scrambler_buffer.data(),
+      this->GenCodeblock(Direction::kUplink,
+                         reinterpret_cast<int8_t*>(ul_scrambler_buffer.data()),
                          ul_encoded_codewords.at(cb));
     }
 
@@ -461,7 +462,6 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
   /* ------------------------------------------------
    * Generate data for downlink test
    * ------------------------------------------------ */
-  const size_t dl_cb_bytes = cfg_->NumBytesPerCb(Direction::kDownlink);
   const LDPCconfig dl_ldpc_config =
       this->cfg_->LdpcConfig(Direction::kDownlink);
   const size_t dl_cb_bytes = cfg_->NumBytesPerCb(Direction::kDownlink);
@@ -563,9 +563,9 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
       if (this->cfg_->ScrambleEnabled()) {
         scrambler->Scramble(dl_scrambler_buffer.data(), dl_cb_bytes);
       }
-      std::memset(&dl_scrambler_buffer.at(dl_cb_byte)], 0u,
-                  dl_cb_padding);
-      this->GenCodeblock(Direction::kDownlink, dl_scrambler_buffer.data(),
+      std::memset(&dl_scrambler_buffer.at(dl_cb_bytes), 0u, dl_cb_padding);
+      this->GenCodeblock(Direction::kDownlink,
+                         reinterpret_cast<int8_t*>(dl_scrambler_buffer.data()),
                          dl_encoded_codewords.at(cb));
     }
 

--- a/src/data_generator/data_generator.cc
+++ b/src/data_generator/data_generator.cc
@@ -82,10 +82,10 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
         pkt->Set(0, pkt_id, ue_id,
                  cfg_->MacPayloadMaxLength(Direction::kUplink));
         this->GenMacData(pkt, ue_id);
-        pkt->Crc((uint16_t)(crc_obj->CalculateCrc24(
-                                pkt->Data(),
-                                cfg_->MacPayloadMaxLength(Direction::kUplink)) &
-                            0xFFFF));
+        pkt->Crc((uint16_t)(
+            crc_obj->CalculateCrc24(
+                pkt->Data(), cfg_->MacPayloadMaxLength(Direction::kUplink)) &
+            0xFFFF));
       }
     }
 
@@ -163,7 +163,7 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
         scrambler->Scramble(ul_scrambler_buffer.data(), ul_cb_bytes);
       }
 
-      if (ul_cb_bytes > 0) {
+      if (ul_cb_padding > 0) {
         std::memset(&ul_scrambler_buffer.at(ul_cb_bytes), 0u, ul_cb_padding);
       }
       this->GenCodeblock(Direction::kUplink,
@@ -491,10 +491,10 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
         pkt->Set(0, pkt_id, ue_id,
                  cfg_->MacPayloadMaxLength(Direction::kDownlink));
         this->GenMacData(pkt, ue_id);
-        pkt->Crc((uint16_t)(crc_obj->CalculateCrc24(pkt->Data(),
-                                                    cfg_->MacPayloadMaxLength(
-                                                        Direction::kDownlink)) &
-                            0xFFFF));
+        pkt->Crc((uint16_t)(
+            crc_obj->CalculateCrc24(
+                pkt->Data(), cfg_->MacPayloadMaxLength(Direction::kDownlink)) &
+            0xFFFF));
       }
     }
 

--- a/src/data_generator/data_generator.cc
+++ b/src/data_generator/data_generator.cc
@@ -465,7 +465,7 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
   const LDPCconfig dl_ldpc_config =
       this->cfg_->LdpcConfig(Direction::kDownlink);
   const size_t dl_cb_bytes = cfg_->NumBytesPerCb(Direction::kDownlink);
-  const size_t dl_cb_padding = cfg_->NumPaddingBytesPerCb(Direction::kDownlink);
+  const size_t dl_cb_padding = kLdpcHelperFunctionInputBufferSizePaddingBytes;
 
   SimdAlignByteVector dl_scrambler_buffer(dl_cb_bytes + dl_cb_padding,
                                           std::byte(0));

--- a/src/data_generator/data_generator.cc
+++ b/src/data_generator/data_generator.cc
@@ -61,8 +61,7 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
   //    LdpcEncodingInputBufSize(this->cfg_->LdpcConfig().BaseGraph(),
   //                             this->cfg_->LdpcConfig().ExpansionFactor());
 
-  auto* ul_scrambler_buffer =
-      new int8_t[ul_cb_bytes + kLdpcHelperFunctionInputBufferSizePaddingBytes];
+  auto* ul_scrambler_buffer = new int8_t[Roundup<64>(ul_cb_bytes)];
 
   // Step 1: Generate the information buffers (MAC Packets) and LDPC-encoded
   // buffers for uplink
@@ -164,7 +163,7 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
         scrambler->Scramble(ul_scrambler_buffer, ul_cb_bytes);
       }
       std::memset(&ul_scrambler_buffer[ul_cb_bytes], 0u,
-                  kLdpcHelperFunctionInputBufferSizePaddingBytes);
+                  this->cfg_->NumPaddingBytesPerCb(Direction::kUplink));
       this->GenCodeblock(Direction::kUplink, ul_scrambler_buffer,
                          ul_encoded_codewords.at(cb));
     }
@@ -465,8 +464,7 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
    * ------------------------------------------------ */
   size_t dl_cb_bytes = cfg_->NumBytesPerCb(Direction::kDownlink);
   LDPCconfig dl_ldpc_config = this->cfg_->LdpcConfig(Direction::kDownlink);
-  auto* dl_scrambler_buffer =
-      new int8_t[dl_cb_bytes + kLdpcHelperFunctionInputBufferSizePaddingBytes];
+  auto* dl_scrambler_buffer = new int8_t[Roundup<64>(dl_cb_bytes)];
   if (this->cfg_->Frame().NumDLSyms() > 0) {
     const size_t num_dl_mac_bytes =
         this->cfg_->MacBytesNumPerframe(Direction::kDownlink);
@@ -561,7 +559,7 @@ void DataGenerator::DoDataGeneration(const std::string& directory) {
         scrambler->Scramble(dl_scrambler_buffer, dl_cb_bytes);
       }
       std::memset(&dl_scrambler_buffer[dl_cb_bytes], 0u,
-                  kLdpcHelperFunctionInputBufferSizePaddingBytes);
+                  this->cfg_->NumPaddingBytesPerCb(Direction::kDownlink));
       this->GenCodeblock(Direction::kDownlink, dl_scrambler_buffer,
                          dl_encoded_codewords.at(cb));
     }

--- a/test/compute_kernels/ldpc/test_ldpc_baseband.cc
+++ b/test/compute_kernels/ldpc/test_ldpc_baseband.cc
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) {
 
   const size_t num_codeblocks = num_cbs_per_ue * cfg->UeAntNum();
   std::printf("Total number of blocks: %zu\n", num_codeblocks);
-  size_t input_size = LdpcEncodingInputBufSize(
-      cfg->LdpcConfig(dir).BaseGraph(), cfg->LdpcConfig(dir).ExpansionFactor());
-  auto* input_ptr =
-      new int8_t[input_size + kLdpcHelperFunctionInputBufferSizePaddingBytes];
+  size_t input_size = Roundup<64>(
+      LdpcEncodingInputBufSize(cfg->LdpcConfig(dir).BaseGraph(),
+                               cfg->LdpcConfig(dir).ExpansionFactor()));
+  auto* input_ptr = new int8_t[input_size];
   for (size_t noise_id = 0; noise_id < 15; noise_id++) {
     std::vector<std::vector<int8_t>> information(num_codeblocks);
     std::vector<std::vector<int8_t>> encoded_codewords(num_codeblocks);

--- a/test/compute_kernels/ldpc/test_ldpc_mod.cc
+++ b/test/compute_kernels/ldpc/test_ldpc_mod.cc
@@ -95,10 +95,10 @@ int main(int argc, char* argv[]) {
 
   const size_t num_codeblocks = num_cbs_per_ue * cfg->UeAntNum();
   std::printf("Total number of blocks: %zu\n", num_codeblocks);
-  size_t input_size = LdpcEncodingInputBufSize(
-      cfg->LdpcConfig(dir).BaseGraph(), cfg->LdpcConfig(dir).ExpansionFactor());
-  auto* input_ptr =
-      new int8_t[input_size + kLdpcHelperFunctionInputBufferSizePaddingBytes];
+  size_t input_size = Roundup<64>(
+      LdpcEncodingInputBufSize(cfg->LdpcConfig(dir).BaseGraph(),
+                               cfg->LdpcConfig(dir).ExpansionFactor()));
+  auto* input_ptr = new int8_t[input_size];
   for (size_t noise_id = 0; noise_id < 15; noise_id++) {
     std::vector<std::vector<int8_t>> information(num_codeblocks);
     std::vector<std::vector<int8_t>> encoded_codewords(num_codeblocks);


### PR DESCRIPTION
High EVM issue when scrambler is off is fixed by copying Tx data bits to scrambler_buffer_ and resetting the padding bytes before passing the buffer into LdpcEncodeHelper. The same method exists in data_generator.cc.